### PR TITLE
Add support for PackageDev settings completions/tooltips/linting.

### DIFF
--- a/Preferences.sublime-settings
+++ b/Preferences.sublime-settings
@@ -1,0 +1,44 @@
+{
+    // Global kill switch to prevent popups (created by MdPopups) from appearing.
+    "mdpopups.disable": false,
+
+    // Controls which information are dumped out to the console.
+    // This is more useful for plugin developers. It works by specifying an error level.
+    // "0" don't print any message
+    // "1" print errors
+    // "2" print errors, warnings
+    // "3" print errors, warnings, debug infos
+    "mdpopups.debug": 0,
+
+    // Control how long a CSS theme file will be in the cache before being refreshed.
+    // Value should be a positive integer greater than 0.
+    // Units are in minutes. Default is 30.
+    "mdpopups.cache_refresh_time": 30,
+
+    // Control how many CSS theme files will be kept in cache at any given time.
+    // Value should be a positive integer greater than or equal to 0.
+    "mdpopups.cache_limit": 10,
+
+    // Controls whether the Pygments or the native Sublime syntax highlighter
+    // is used for code highlighting. This affects code highlighting in Markdown
+    // conversion and when code is directly processed using syntax_highlight.
+    // Valid values are:
+    //   "true": use Sublime Text
+    //   "false": use Pygments
+    "mdpopups.use_sublime_highlighter": true,
+
+    // This setting is for the Sublime Syntax Highlighter and allows
+    // the mapping of personal Sublime syntax languages which are not yet included,
+    // or will not be included, in the official mapping table.
+    // You can either define your own new entry, or use the same language name
+    // of an existing entry to extend the language mapping_alias or syntax languages.
+    // When extending, the user mappings will be cycled through first.
+    "mdpopups.sublime_user_lang_map": {},
+
+    // Controls whether MdPopups' default styling (contained in default.css) will be applied or not.
+    "mdpopups.default_style": true,
+
+    // Relative path of the user defined stylesheet.
+    // Overrides the default CSS and/or CSS of plugins.
+    "mdpopups.user_css": "Packages/User/mdpopups.css"
+}


### PR DESCRIPTION
PackageDev 3 supports completions, tooltips and linting of sublime settings files. Therefore each package needs to provide a `*.sublime-settings` or `*.sublime-settings-hints` file to let PackageDev know about valid keys and their description.

Would be cool to get mdpopups completions as well.
