### PR TITLE
restore fontsize to 1rem for code blocks

### DIFF
--- a/css/default.css
+++ b/css/default.css
@@ -199,6 +199,7 @@ div.mdpopups {
 .mdpopups pre.highlight {
   padding: 0.5rem;
   margin-bottom: 0.5rem;
+  font-size: 1rem;
 }
 .mdpopups code.highlight{
   padding: 0.05rem 0.25rem;


### PR DESCRIPTION
As discussed [here](https://github.com/tomv564/LSP/pull/168#issuecomment-335914911) code blocks should be at 1rem font-size, while inline code elements should stay at 0.9rem. This change still downsizes the general `.highlight` selector, and then sets it back to 1rem specifically for block elements. Tested for correct behaviour in LSP.