### PR TITLE
add mappings for TypeScript and Less

### DIFF
--- a/st3/mdpopups/st_mapping.py
+++ b/st3/mdpopups/st_mapping.py
@@ -49,7 +49,7 @@ lang_map = {
     'tex': (('tex', 'latex'), ('LaTeX/LaTeX',)),
     'text': (('text',), ('Text/Plain text',)),
     'textile': (('textile',), ('Textile/Textile',)),
-    'typescript': (('typescript', 'ts'), ('TypeScript/TypeScript','TypeScriptSyntax/TypeScript')),
+    'typescript': (('typescript', 'ts'), ('TypeScript/TypeScript', 'TypeScriptSyntax/TypeScript')),
     'xml': (('xml',), ('XML/XML',)),
     'yaml': (('yaml',), ('YAML/YAML',))
 }

--- a/st3/mdpopups/st_mapping.py
+++ b/st3/mdpopups/st_mapping.py
@@ -24,6 +24,7 @@ lang_map = {
     'javascript': (('javascript', 'js'), ('JavaScript/JavaScript', 'JavaScriptNext - ES6 Syntax/JavaScriptNext')),
     'json': (('json',), ('JavaScript/JSON', 'JavaScriptNext - ES6 Syntax/JSON (JavaScriptNext)')),
     'jsp': (('jsp',), ('Java/Java Server Pages (JSP)',)),
+    'less': (('less',), ('LESS/LESS', 'LessImproved/LESS')),
     'lisp': (('common-lisp', 'cl', 'lisp', 'emacs', 'elisp'), ('Lisp/Lisp',)),
     'lua': (('lua',), ('Lua/Lua',)),
     'markdown': (('markdown', 'md'), ('Markdown/Markdown',)),
@@ -48,6 +49,7 @@ lang_map = {
     'tex': (('tex', 'latex'), ('LaTeX/LaTeX',)),
     'text': (('text',), ('Text/Plain text',)),
     'textile': (('textile',), ('Textile/Textile',)),
+    'typescript': (('typescript', 'ts'), ('TypeScript/TypeScript','TypeScriptSyntax/TypeScript')),
     'xml': (('xml',), ('XML/XML',)),
     'yaml': (('yaml',), ('YAML/YAML',))
 }


### PR DESCRIPTION
Adds highlighting for the (not-in-default-packages) languages TypeScript and Less, for their most popular packages.