### PR TITLE
Hashed syntax highlight support

### DIFF
--- a/docs/src/markdown/changelog.md
+++ b/docs/src/markdown/changelog.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 3.1.0
+
+> Nov 3, 2017
+
+- **NEW**: Handle parsing `.sublime-color-scheme` files with hashed syntax highlighting foreground colors.
+- **FIX**: Rework `*.sublime-color-scheme` merging and ensure `User` package is merged last.
+
 ## 3.0.5
 
 > Oct 30, 2017

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -7,6 +7,19 @@ copyright: |
   Copyright &copy; 2015 - 2017 <a href="https://github.com/facelessuser">Isaac Muse</a>
   <br><span class="md-footer-custom-text">emoji provided free by </span><a href="http://www.emojione.com">EmojiOne</a>
 
+docs_dir: docs/src/markdown
+theme:
+  name: material
+  custom_dir: docs/theme
+  palette:
+    primary: blue
+    accent: blue
+  logo:
+    icon: description
+  font:
+    text: Roboto
+    code: Roboto Mono
+
 pages:
   - About Markdown Popups: index.md
   - Installation: installation.md
@@ -17,10 +30,6 @@ pages:
   - Contributing &amp; Support: contributing.md
   - Changelog: changelog.md
   - License: license.md
-
-theme: material
-docs_dir: docs/src/markdown
-theme_dir: docs/theme
 
 markdown_extensions:
   - markdown.extensions.toc:
@@ -67,12 +76,6 @@ markdown_extensions:
   - pymdownx.details:
 
 extra:
-  palette:
-    primary: blue
-    accent: blue
-  font:
-    text: Roboto
-    code: Roboto Mono
   social:
     - type: github
       link: https://github.com/facelessuser

--- a/st3/mdpopups/st_color_scheme_matcher.py
+++ b/st3/mdpopups/st_color_scheme_matcher.py
@@ -309,7 +309,10 @@ def sublime_format_path(pth):
 class SchemeColors(
     namedtuple(
         'SchemeColors',
-        ['fg', 'fg_simulated', 'bg', "bg_simulated", "style", "fg_selector", "bg_selector", "style_selectors"],
+        [
+            'fg', 'fg_simulated', 'bg', "bg_simulated", "style", "color_gradient",
+            "fg_selector", "bg_selector", "style_selectors", "color_gradient_selector"
+        ],
         verbose=False
     )
 ):
@@ -459,7 +462,10 @@ class ColorSchemeMatcher(object):
             style = []
             if scope is not None:
                 color = item.get('foreground', None)
-                if color is not None:
+                if isinstance(color, list):
+                    for index, c in enumerate(color):
+                        color[index] = translate_color(COLOR_RE.match(c.strip()), self.variables, {})
+                elif color is not None:
                     color = translate_color(COLOR_RE.match(color.strip()), self.variables, {})
                 bgcolor = item.get('background', None)
                 if bgcolor is not None:
@@ -478,7 +484,10 @@ class ColorSchemeMatcher(object):
     def add_entry(self, name, scope, color, bgcolor, scolor, style):
         """Add color entry."""
 
-        if color is not None:
+        color_gradient = None
+        if isinstance(color, list):
+            fg, fg_sim, color_gradient = self.process_color_gradient(color)
+        elif color is not None:
             fg, fg_sim = self.process_color(color)
         else:
             fg, fg_sim = None, None
@@ -497,12 +506,44 @@ class ColorSchemeMatcher(object):
             "scope": scope,
             "color": fg,
             "color_simulated": fg_sim,
+            "color_gradient": color_gradient,
             "bgcolor": bg,
             "bgcolor_simulated": bg_sim,
             "selection_color": sfg,
             "selection_color_simulated": sfg_sim,
             "style": style
         }
+
+    def process_color_gradient(self, colors, simple_strip=False, bground=None):
+        """
+        Strip transparency from the color gradient list.
+
+        Transparency can be stripped in one of two ways:
+            - Simply mask off the alpha channel.
+            - Apply the alpha channel to the color essential getting the color seen by the eye.
+        """
+
+        gradient = []
+
+        for color in colors:
+            if color is None or color.strip() == "":
+                continue
+
+            if not color.startswith('#'):
+                continue
+
+            rgba = RGBA(color.replace(" ", ""))
+            if not simple_strip:
+                if bground is None:
+                    bground = self.special_colors['background']['color_simulated']
+                rgba.apply_alpha(bground if bground != "" else "#FFFFFF")
+
+            gradient.append((color, rgba.get_rgb()))
+        if gradient:
+            color, color_sim = gradient[0]
+            return color, color_sim, gradient
+        else:
+            return None, None, None
 
     def process_color(self, color, simple_strip=False, bground=None):
         """
@@ -565,6 +606,8 @@ class ColorSchemeMatcher(object):
 
         color = self.special_colors['foreground']['color']
         color_sim = self.special_colors['foreground']['color_simulated']
+        color_gradient = None
+        color_gradient_selector = None
         bgcolor = self.special_colors['background']['color'] if not explicit_background else None
         bgcolor_sim = self.special_colors['background']['color_simulated'] if not explicit_background else None
         scolor = self.special_colors['selection_foreground']['color']
@@ -577,6 +620,7 @@ class ColorSchemeMatcher(object):
         if scope_key in self.matched:
             color = self.matched[scope_key]["color"]
             color_sim = self.matched[scope_key]["color_simulated"]
+            color_gradient = self.matched[scope_key]["color_gradient"]
             style = self.matched[scope_key]["style"]
             bgcolor = self.matched[scope_key]["bgcolor"]
             bgcolor_sim = self.matched[scope_key]["bgcolor_simulated"]
@@ -587,18 +631,31 @@ class ColorSchemeMatcher(object):
             bg_selector = selectors["background"]
             scolor_selector = selectors["scolor"]
             style_selectors = selectors["style"]
+            color_gradient_selector = selectors['color_gradient']
         else:
             best_match_bg = 0
             best_match_fg = 0
             best_match_style = 0
             best_match_sfg = 0
+            best_match_fg_gradient = 0
             for key in self.colors:
                 match = sublime.score_selector(scope_key, key)
-                if self.colors[key]["color"] is not None and match > best_match_fg:
+                if (
+                    not self.colors[key]['color_gradient'] and
+                    self.colors[key]["color"] is not None and
+                    match > best_match_fg
+                ):
                     best_match_fg = match
                     color = self.colors[key]["color"]
                     color_sim = self.colors[key]["color_simulated"]
                     color_selector = SchemeSelectors(self.colors[key]["name"], self.colors[key]["scope"])
+                if (
+                    self.colors[key]["color"] is not None and
+                    match > best_match_fg_gradient
+                ):
+                    best_match_fg_gradient = match
+                    color_gradient = self.colors[key]["color_gradient"]
+                    color_gradient_selector = SchemeSelectors(self.colors[key]["name"], self.colors[key]["scope"])
                 if self.colors[key]["selection_color"] is not None and match > best_match_sfg:
                     best_match_sfg = match
                     scolor = self.colors[key]["selection_color"]
@@ -634,12 +691,14 @@ class ColorSchemeMatcher(object):
                 "color_simulated": color_sim,
                 "bgcolor_simulated": bgcolor_sim,
                 "scolor_simulated": scolor_sim,
+                "color_gradient": color_gradient,
                 "style": style,
                 "selectors": {
                     "color": color_selector,
                     "background": bg_selector,
                     "scolor": scolor_selector,
-                    "style": style_selectors
+                    "style": style_selectors,
+                    "color_gradient": (color_gradient_selector if color_gradient else None)
                 }
             }
 
@@ -648,12 +707,14 @@ class ColorSchemeMatcher(object):
                 color = scolor
                 color_sim = scolor_sim
                 color_selector = scolor_selector
+                color_gradient = None
+                color_gradient_selector = None
             if self.special_colors['selection']['color']:
                 bgcolor = self.special_colors['selection']['color']
                 bgcolor_sim = self.special_colors['selection']['color_simulated']
                 bg_selector = SchemeSelectors("selection", "selection")
 
         return SchemeColors(
-            color, color_sim, bgcolor, bgcolor_sim, style,
-            color_selector, bg_selector, style_selectors
+            color, color_sim, bgcolor, bgcolor_sim, style, color_gradient,
+            color_selector, bg_selector, style_selectors, color_gradient_selector
         )

--- a/st3/mdpopups/version.py
+++ b/st3/mdpopups/version.py
@@ -1,6 +1,6 @@
 """Version."""
 
-_version_info = (3, 0, 5)
+_version_info = (3, 1, 0)
 __version__ = '.'.join([str(x) for x in _version_info])
 
 


### PR DESCRIPTION
Ref #46 

As far as anyone is concerned, things will behave like they always did, but the parser will handle the lists for hashed syntax, but they will not be included in color calculation for scopes as it isn't practical in CSS.