### PR TITLE
Added VHDL and Verilog mappings.

### DIFF
--- a/st3/mdpopups/st_mapping.py
+++ b/st3/mdpopups/st_mapping.py
@@ -52,5 +52,7 @@ lang_map = {
     'textile': (('textile',), ('Textile/Textile',)),
     'typescript': (('typescript', 'ts'), ('TypeScript/TypeScript', 'TypeScript Syntax/TypeScript')),
     'xml': (('xml',), ('XML/XML',)),
-    'yaml': (('yaml',), ('YAML/YAML',))
+    'yaml': (('yaml',), ('YAML/YAML',)),
+    'vhdl': (('vhdl',), ('VHDL/Syntaxes/VHDL', 'HDLProject/sublime-vhdl/Syntaxes/VHDL')),
+    'verilog': (('verilog',), ('Verilog/Verilog', 'HDLProject/sublime-verilog/Verilog'))
 }


### PR DESCRIPTION
I have started using mdpopups for my HDLProject plugin. Before I push the changes for my plugin, I wanted to make sure these mappings get added. 