### PR TITLE
add elm support

### DIFF
--- a/st3/mdpopups/st_mapping.py
+++ b/st3/mdpopups/st_mapping.py
@@ -16,6 +16,7 @@ lang_map = {
     'd': (('d',), ('D/D',)),
     'diff': (('diff',), ('Diff/Diff',)),
     'erlang': (('erlang',), ('Erlang/Erlang',)),
+    'elm': (('elm',), ('Elm Syntax Highlighting/src/elm',)),
     'go': (('go',), ('Go/Go',)),
     'groovy': (('groovy',), ('Groovy/Groovy',)),
     'haskell': (('haskell', 'hs'), ('Haskell/Haskell',)),


### PR DESCRIPTION
Add elm support for syntax highlighting in popups

Before:
![2019-09-01-122038_1366x768_scrot](https://user-images.githubusercontent.com/22029477/64075026-2bf1f400-ccb3-11e9-8a3a-2987dcedd359.png)

After:
![2019-09-01-121615_653x728_scrot](https://user-images.githubusercontent.com/22029477/64075030-301e1180-ccb3-11e9-9595-a31ca77613b3.png)
