### PR TITLE
Color fixes

### DIFF
--- a/docs/src/markdown/changelog.md
+++ b/docs/src/markdown/changelog.md
@@ -4,6 +4,10 @@
 
 - **FIX**: Color adjusters with `+` and `-` operator must have a space after the operator.
 - **FIX**: `lightness()` and `saturation()` should not accept numbers, only percentages.
+- **FIX**: Adjustments to match Sublime 4069 which now handles HSL color blending correctly.
+- **FIX**: Handle HSL/HWB if a user uses the 'deg' unit type.
+- **FIX**: Sublime doesn't support them, but support 'rad', 'grad', and 'turn' unit types in case Sublime ever supports
+  them in HSL an HWB.
 
 ## 3.6.0
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -12,10 +12,10 @@ docs_dir: docs/src/markdown
 theme:
   name: material
   palette:
-    primary: blue
-    accent: blue
-  logo:
-    icon: description
+    primary: drac-purple
+    accent: drac-purple
+  icon:
+    logo: material/book-open-page-variant
   font:
     text: Roboto
     code: Roboto Mono
@@ -58,7 +58,6 @@ markdown_extensions:
           class: arithmatex
           format: !!python/name:pymdownx.arithmatex.fence_mathjax_format
   - pymdownx.highlight:
-      css_class: codehilite
       extend_pygments_lang:
         - name: php-inline
           lang: php
@@ -101,7 +100,14 @@ markdown_extensions:
 
 extra:
   social:
-    - icon: brands/github
+    - icon: fontawesome/brands/github
       link: https://github.com/facelessuser
-    - icon: brands/discord
+    - icon: fontawesome/brands/discord
       link: https://discord.gg/rZ2n3Dy
+
+plugins:
+  - search
+  - git-revision-date-localized
+  - mkdocs_pymdownx_material_extras
+  - minify:
+      minify_html: true

--- a/st3/mdpopups/rgba.py
+++ b/st3/mdpopups/rgba.py
@@ -2,11 +2,14 @@
 RGBA.
 
 Licensed under MIT
-Copyright (c) 2012 - 2020 Isaac Muse <isaacmuse@gmail.com>
+Copyright (c) 2012 - 2016 Isaac Muse <isaacmuse@gmail.com>
 """
 import re
 from colorsys import rgb_to_hls, hls_to_rgb, rgb_to_hsv, hsv_to_rgb
 import decimal
+import sublime
+
+HSL_WORKAROUND = int(sublime.version()) < 4069
 
 RGB_CHANNEL_SCALE = 1.0 / 255.0
 HUE_SCALE = 1.0 / 360.0
@@ -54,8 +57,10 @@ def hue_blend_channel(c1, c2, f):
             c1 += 360.0
         else:
             c2 += 360.0
-    # This shouldn't be necessary and is probably a bug in Sublime.
-    f = 1.0 - f
+
+    if HSL_WORKAROUND:
+        # This shouldn't be necessary and is probably a bug in Sublime.
+        f = 1.0 - f
 
     value = abs(c1 * f + c2 * (1 - f))
     while value > 360.0:

--- a/tox.ini
+++ b/tox.ini
@@ -11,8 +11,9 @@ commands=
 
 [testenv:documents]
 deps=
-    mkdocs_pymdownx_material_extras==1.0b4
+    mkdocs_pymdownx_material_extras==1.0b11
     mkdocs-git-revision-date-localized-plugin
+    mkdocs-minify-plugin
     pyspelling
 commands=
     mkdocs build --clean --verbose --strict


### PR DESCRIPTION
- Adjustments to match Sublime 4069 which now handles HSL color blending
  correctly.
- Handle HSL if a user use the 'deg' unit type
- Sublime doesn't support them, but support 'rad', 'grad', and 'turn'
  unit types in case Sublime ever supports them in HSL an HWB.