### PR TITLE
Recognize glow and underline style and render when possible

### DIFF
--- a/docs/src/markdown/changelog.md
+++ b/docs/src/markdown/changelog.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 3.7.0
+
+- **NEW**: Add support for `underline` and `glow` in highlighted code blocks.
+
+  Currently Sublime's API has a bug
+  (https://github.com/sublimehq/sublime_text/issues/3316) that prevents underline from being detected, you can enable
+  the `mdpopups.legacy_color_matcher` to work around this issue until it is fixed. But keep in mind, leg this is not
+  required as MdPopups will continue working just fine, just without showing underlines in highlighted code.
+
+  While `glow` support has been added, it will not actually display proper in `minihtml` as `minihtml` cannot yet
+  support the CSS `text-shadow` feature that is used to create the glow effect. If/when this support is added to
+  Sublime, the glow effect *should* work.
+
+- **NEW**: Add option `mdpopups.legacy_color_matcher` to enable the legacy color matcher.
+
 ## 3.6.2
 
 - **FIX**: Sublime Text 4 no longer supports `cmd` and `args` in HTML sheets. Additionally, version 4074 will be

--- a/docs/src/markdown/settings.md
+++ b/docs/src/markdown/settings.md
@@ -78,4 +78,12 @@ For a list of all currently supported syntax mappings, see the official [mapping
 !!! tip "Tip"
     When submitting new languages to the mapping table, it is encouraged to pick key names that correspond to what is used in Pygments so a User can switch between Pygments' and Sublime's syntax highlighter and still get highlighting.
 
+## `mdpopups.legacy_color_matcher`
+
+Enables the legacy color matcher instead of using the Sublime API. Sometimes this can be useful to work around bugs in
+the Sublime API. In general it is recommended to leave this set to `#!py3 False`.
+
+!!! new "New 3.7.0"
+    Added `mdpopups.legacy_color_matcher` in 3.7.0.
+
 --8<-- "refs.txt"

--- a/st3/mdpopups/__init__.py
+++ b/st3/mdpopups/__init__.py
@@ -46,6 +46,7 @@ there are helpful errors.</p></div>
 '''
 HL_SETTING = 'mdpopups.use_sublime_highlighter'
 STYLE_SETTING = 'mdpopups.default_style'
+LEGACY_MATCHER_SETTING = 'mdpopups.legacy_color_matcher'
 RE_BAD_ENTITIES = re.compile(r'(&(?!amp;|lt;|gt;|nbsp;)(?:\w+;|#\d+;))')
 
 NODEBUG = 0
@@ -172,7 +173,8 @@ def _get_scheme(scheme):
             if (
                 _is_cache_expired(t) or
                 obj.use_pygments != (not settings.get(HL_SETTING, True)) or
-                obj.default_style != settings.get(STYLE_SETTING, True)
+                obj.default_style != settings.get(STYLE_SETTING, True) or
+                obj.legacy_color_matcher != settings.get(LEGACY_MATCHER_SETTING, False)
             ):
                 obj = None
                 user_css = ''

--- a/st3/mdpopups/st_color_scheme_matcher.py
+++ b/st3/mdpopups/st_color_scheme_matcher.py
@@ -674,7 +674,7 @@ class ColorSchemeMatcher(object):
                 # Font style
                 if FONT_STYLE in item:
                     for s in item.get(FONT_STYLE, '').split(' '):
-                        if s == "bold" or s == "italic":  # or s == "underline":
+                        if s in ('bold', 'italic', 'underline', 'glow'):
                             style.append(s)
 
                 self.add_entry(name, scope, color, bgcolor, fgadj, scolor, style)
@@ -816,7 +816,12 @@ class ColorSchemeMatcher(object):
         color_selector = SchemeSelectors("foreground", "foreground")
         bg_selector = SchemeSelectors("background", "background")
         scolor_selector = SchemeSelectors("selection_foreground", "selection_foreground")
-        style_selectors = {"bold": SchemeSelectors("", ""), "italic": SchemeSelectors("", "")}
+        style_selectors = {
+            "bold": SchemeSelectors("", ""),
+            "italic": SchemeSelectors("", ""),
+            "underline": SchemeSelectors("", ""),
+            "glow": SchemeSelectors("", "")
+        }
         if scope_key in self.matched:
             color = self.matched[scope_key]["color"]
             color_sim = self.matched[scope_key]["color_simulated"]
@@ -872,6 +877,14 @@ class ColorSchemeMatcher(object):
                             )
                         elif s == "italic":
                             style_selectors["italic"] = SchemeSelectors(
+                                self.colors[key]["name"], self.colors[key]["scope"]
+                            )
+                        elif s == "underline":
+                            style_selectors["underline"] = SchemeSelectors(
+                                self.colors[key]["name"], self.colors[key]["scope"]
+                            )
+                        elif s == "glow":
+                            style_selectors["glow"] = SchemeSelectors(
                                 self.colors[key]["name"], self.colors[key]["scope"]
                             )
                 if self.colors[key]["bgcolor"] is not None and match > best_match_bg:

--- a/st3/mdpopups/st_scheme_template.py
+++ b/st3/mdpopups/st_scheme_template.py
@@ -145,7 +145,7 @@ class SchemeTemplate(object):
     def get_html_border(self):
         """Get HTML border."""
 
-        return self.get_bg() if not legacy_color_matcher else self.html_border
+        return self.get_bg() if not self.legacy_color_matcher else self.html_border
 
     def is_dark(self):
         """Check if scheme is dark."""

--- a/st3/mdpopups/st_scheme_template.py
+++ b/st3/mdpopups/st_scheme_template.py
@@ -77,15 +77,17 @@ class SchemeTemplate(object):
         """Guess color."""
 
         # Remove leading '.' to account for old style CSS class scopes.
-        if not NEW_SCHEMES:
+        if self.legacy_color_matcher:
             return self.csm.guess_color(scope.lstrip('.'), selected, explicit_background)
         else:
             scope_style = view.style_for_scope(scope.lstrip('.'))
             style = {}
             style['foreground'] = scope_style['foreground']
             style['background'] = scope_style.get('background')
-            style['bold'] = scope_style['bold']
-            style['italic'] = scope_style['italic']
+            style['bold'] = scope_style.get('bold', False)
+            style['italic'] = scope_style.get('italic', False)
+            style['underline'] = scope_style.get('underline', False)
+            style['glow'] = scope_style.get('glow', False)
 
             defaults = view.style()
             if not explicit_background and not style.get('background'):
@@ -126,7 +128,7 @@ class SchemeTemplate(object):
     def get_variables(self):
         """Get variables."""
 
-        if NEW_SCHEMES:
+        if not self.legacy_color_matcher:
             is_dark = self.is_dark()
             return {
                 "is_dark": is_dark,
@@ -143,7 +145,7 @@ class SchemeTemplate(object):
     def get_html_border(self):
         """Get HTML border."""
 
-        return self.get_bg() if NEW_SCHEMES else self.html_border
+        return self.get_bg() if not legacy_color_matcher else self.html_border
 
     def is_dark(self):
         """Check if scheme is dark."""
@@ -153,7 +155,7 @@ class SchemeTemplate(object):
     def get_lums(self):
         """Get luminance."""
 
-        if NEW_SCHEMES:
+        if not self.legacy_color_matcher:
             bg = self.get_bg()
             rgba = RGBA(bg)
             return rgba.get_true_luminance()
@@ -163,12 +165,12 @@ class SchemeTemplate(object):
     def get_fg(self):
         """Get foreground."""
 
-        return self.view.style().get('foreground', '#000000') if NEW_SCHEMES else self.fground
+        return self.view.style().get('foreground', '#000000') if not self.legacy_color_matcher else self.fground
 
     def get_bg(self):
         """Get background."""
 
-        return self.view.style().get('background', '#FFFFFF') if NEW_SCHEMES else self.bground
+        return self.view.style().get('background', '#FFFFFF') if not self.legacy_color_matcher else self.bground
 
     def setup(self):
         """Setup the template environment."""
@@ -176,8 +178,9 @@ class SchemeTemplate(object):
         settings = sublime.load_settings("Preferences.sublime-settings")
         self.use_pygments = not settings.get('mdpopups.use_sublime_highlighter', True)
         self.default_style = settings.get('mdpopups.default_style', True)
+        self.legacy_color_matcher = not NEW_SCHEMES or settings.get('mdpopups.legacy_color_matcher', False)
 
-        if not NEW_SCHEMES:
+        if self.legacy_color_matcher:
             self.legacy_parse_global()
 
         # Create Jinja template
@@ -349,7 +352,7 @@ class SchemeTemplate(object):
     def retrieve_selector(self, selector, key=None, explicit_background=True):
         """Get the CSS key, value pairs for a rule."""
 
-        if NEW_SCHEMES:
+        if not self.legacy_color_matcher:
             general = self.view.style()
             fg = general.get('foreground', '#000000')
             bg = general.get('background', '#ffffff')
@@ -377,8 +380,10 @@ class SchemeTemplate(object):
                 css.append('font-weight: bold')
             if "italic" in s and (key is None or key == 'font-style'):
                 css.append('font-style: italic')
-            if "underline" in s and (key is None or key == 'text-decoration') and False:  # disabled
+            if "underline" in s and (key is None or key == 'text-decoration'):
                 css.append('text-decoration: underline')
+            if "glow" in s and (key is None or key == 'text-shadow'):
+                css.append('text-shadow: 0 0 3px currentColor')
         text = ';'.join(css)
         if text:
             text += ';'

--- a/st3/mdpopups/version.py
+++ b/st3/mdpopups/version.py
@@ -1,6 +1,6 @@
 """Version."""
 
-_version_info = (3, 6, 2)
+_version_info = (3, 7, 0)
 __version__ = '.'.join([str(x) for x in _version_info])
 
 


### PR DESCRIPTION
Add a related legacy_color_matcher option to use our internal color
matcher instead of Sublime's API if desired, this is useful when working
around Sublime's API bugs like currently exists for underline.