### PR TITLE
Remove deprecated parameters `nl2br` and `allow_code_wrap`

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,11 @@
 ![License][license-image]
 # Sublime Markdown Popups
 
-Sublime Markdown Popups (mdpopups) is a library for Sublime Text plugins.  It utilizes the new plugin API found in ST3 Beta 3080+ for generating tooltip popups. It also provides API methods for generating and styling the new phantom elements introduced in ST3 Beta 3118+.  Mdpopups utilizes Python Markdown with a couple of special extensions to convert Markdown to HTML that can be used to create the popups and/or phantoms.  It also provides a number of other helpful API commands to aid in creating great tooltips and phantoms.
+Sublime Markdown Popups (mdpopups) is a library for Sublime Text plugins.  It utilizes the new plugin API found in ST3
+3080+ for generating tooltip popups. It also provides API methods for generating and styling the new phantom elements
+introduced in ST3 3118+.  Mdpopups utilizes Python Markdown with a couple of special extensions to convert Markdown to
+HTML that can be used to create the popups and/or phantoms.  It also provides a number of other helpful API commands to
+aid in creating great tooltips and phantoms.
 
 Mdpopups will use your color scheme to create popups/phantoms that fit your editors look.
 
@@ -14,25 +18,37 @@ Mdpopups will use your color scheme to create popups/phantoms that fit your edit
 
 - Can take Markdown or HTML and create nice looking popup tooltips and phantoms.
 - Dynamically creates popup and phantom themes from your current Sublime color scheme.
-- Can create syntax highlighted code blocks easily using either Pygments or the built-in Sublime Text syntax highlighter automatically in the Markdown environment or outside via API calls.
+- Can create syntax highlighted code blocks easily using either Pygments or the built-in Sublime Text syntax highlighter
+  automatically in the Markdown environment or outside via API calls.
 - Can create color preview boxes via API calls.
-- A CSS template environment that allows users to override and tweak the overall look of the tooltip and phantom themes to better fit their preferred look.  Using the template filters, users can generically access color scheme colors and manipulate them.
-- Plugins can extend the current CSS to inject plugin specific class styling.  Extended CSS will be run through the template environment.
+- A CSS template environment that allows users to override and tweak the overall look of the tooltip and phantom themes
+  to better fit their preferred look.  Using the template filters, users can generically access color scheme colors and
+  manipulate them.
+- Plugins can extend the current CSS to inject plugin specific class styling.  Extended CSS will be run through the
+  template environment.
 
 # Documentation
 
 https://facelessuser.github.io/sublime-markdown-popups
 
 # License
+
 Released under the MIT license.
 
 Copyright (c) 2015 - 2020 Isaac Muse <isaacmuse@gmail.com>
 
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+persons to whom the Software is furnished to do so, subject to the following conditions:
 
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+Software.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 [github-ci-image]: https://github.com/facelessuser/sublime-markdown-popups/workflows/build/badge.svg?branch=master&event=push
 [github-ci-link]: https://github.com/facelessuser/sublime-markdown-popups/actions?query=workflow%3Abuild+branch%3Amaster

--- a/docs/src/markdown/_snippets/links.txt
+++ b/docs/src/markdown/_snippets/links.txt
@@ -9,6 +9,7 @@
 [inlinehilite]: http://facelessuser.github.io/pymdown-extensions/extensions/inlinehilite/
 [language-map]: https://github.com/facelessuser/sublime-markdown-popups/blob/master/st3/mdpopups/st_mapping.py
 [magiclink]: http://facelessuser.github.io/pymdown-extensions/extensions/magiclink/
+[md_in_html]: https://pythonhosted.org/Markdown/extensions/extra.html#nested-markdown-inside-html-blocks
 [mdpopup_test]: https://github.com/facelessuser/mdpopup_test
 [mkdocs]: http://www.mkdocs.org
 [minihtml]: https://www.sublimetext.com/docs/3/minihtml.html

--- a/docs/src/markdown/about/changelog.md
+++ b/docs/src/markdown/about/changelog.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 4.0.0
+
+- **NEW**: `nl2br` can only be set through `markdown_extensions` via frontmatter. If passed as a parameter for any API
+  function, it will be ignored.
+- **NEW**: `allow_code_wrap` can only be set through the frontmatter option `allow_code_wrap`. If passed as a parameter
+  for any API function (except `syntax_highlight`), it will be ignored.
+
 ## 3.7.5
 
 - **FIX**: Don't strip newlines from content that has `nl2br` disabled.

--- a/docs/src/markdown/api.md
+++ b/docs/src/markdown/api.md
@@ -20,7 +20,10 @@ Your plugin should include the Package Control dependencies listed below. Please
 }
 ```
 
-Check out @facelessuser/mdpopup_test as an example. Clone it into `Packages/mdpopup_test`, run `Package Control: Satisfy dependencies`, and then restart Sublime. You should be able to then run the command `Mdpopups: Test` to see an example popup or phantom.  Feel free to edit it to learn more.
+Check out @facelessuser/mdpopups_test if to create quick and easy popup tests. Clone it into `Packages/mdpopups_test`,
+run `Package Control: Satisfy dependencies`, and then restart Sublime. You should be able to then run the command
+`Mdpopups: Test` to see an example popup, phantom, or (if on Sublime Text 4) HTML sheet. You can even create output of
+the source HTML for debugging. Feel free to try it out.
 
 ## Markdown Support
 
@@ -106,11 +109,9 @@ The included `mdpopups.mdx.superfences` has an option that allows for custom fen
 custom_fences:
 - name: uml
   class: uml
-  format: !!python/name:mdpopup_test.plantuml.uml_format
+  format: !!python/name:my_package.my_module.my_custom_format
 ...
 ```
-
-Checkout @facelessuser/mdpopup_test to see the UML example above in action.
 
 ### Configure Markdown Extensions
 
@@ -227,11 +228,9 @@ MdPopups provides a number of accessible functions.
     `wrapper_class`        | `#!py3 str`          | `#!py3 None`  | A string containing the class name you wish wrap your content in.  A `div` will be created with the given class.
     `template_vars`        | `#!py3 dict`         | `#!py3 None`  | A dictionary containing template vars.  These can be used in either the CSS or the HTML/Markdown content. These vars are found under the object `plugin`.
     `template_env_options` | `#!py3 dict`         | `#!py3 None`  | A dictionary containing options for the Jinja2 template environment. This **only** applies to the **HTML/Markdown** content.
-    `nl2br`                | `#!py3 bool`         | `#!py3 True`  | Determines whether the newline to `#!html <br>` Python Markdown extension is enabled or not. Will be ignored if `markdown_extensions` is configured in YAML frontmatter.
-    `allow_code_wrap`      | `#!py3 bool`         | `#!py3 False` | Do not convert all the spaces in code blocks to `&nbsp;` so that wrapping can occur. YAML frontmatter's `allow_code_wrap` will always be used instead of this if specified.
 
-    !!! warning "Deprecation"
-        In 2.1.0 `nl2br` and `alow_code_wrap` are deprecated. The legacy parameters here will be dropped by 2018 for ST3 and these settings will not carry over to ST4.
+    !!! alert "Removed in 4.0"
+        4.0 removed the parameter `nl2br` and `alow_code_wrap`. If passed to the function, they will be ignored.
 
         To disable `nl2br`, you can customize which extensions get loaded; see [Configure Markdown Extensions](#configure-markdown-extensions).
 
@@ -252,11 +251,9 @@ MdPopups provides a number of accessible functions.
     `wrapper_class`        | `#!py3 str`          | `#!py3 None`  | A string containing the class name you wish wrap your content in.  A `div` will be created with the given class.
     `template_vars`        | `#!py3 dict`         | `#!py3 None`  | A dictionary containing template vars.  These can be used in either the CSS or the HTML/Markdown content. These vars are found under the object `plugin`.
     `template_env_options` | `#!py3 dict`         | `#!py3 None`  | A dictionary containing options for the Jinja2 template environment. This **only** applies to the **HTML/Markdown** content.
-    `nl2br`                | `#!py3 bool`         | `#!py3 True`  | Determines whether the newline to `#!html <br>` Python Markdown extension is enabled or not. Will be ignored if `markdown_extensions` is configured in YAML frontmatter.
-    `allow_code_wrap`      | `#!py3 bool`         | `#!py3 False` | Do not convert all the spaces in code blocks to `&nbsp;` so that wrapping can occur. YAML frontmatter's `allow_code_wrap` will always be used instead of this if specified.
 
-    !!! warning "Deprecation"
-        In 2.1.0 `nl2br` and `alow_code_wrap` are deprecated. The legacy parameters here will be dropped by 2018 for ST3 and these settings will not carry over to ST4.
+    !!! alert "Removed in 4.0"
+        4.0 removed the parameter `nl2br` and `alow_code_wrap`. If passed to the function, they will be ignored.
 
         To disable `nl2br`, you can customize which extensions get loaded; see [Configure Markdown Extensions](#configure-markdown-extensions).
 
@@ -302,11 +299,9 @@ MdPopups provides a number of accessible functions.
     `wrapper_class`        | `#!py3 str`            | `#!py3 None`  | A string containing the class name you wish wrap your content in.  A `div` will be created with the given class.
     `template_vars`        | `#!py3 dict`           | `#!py3 None`  | A dictionary containing template vars.  These can be used in either the CSS or the HTML/Markdown content.A dictionary containing template vars.  These can be used in either the CSS or the HTML/Markdown content. These vars are found under the object `plugin`.
     `template_env_options` | `#!py3 dict`           | `#!py3 None`  | A dictionary containing options for the Jinja2 template environment. This **only** applies to the **HTML/Markdown** content. Content plugin vars are found under the object: `plugin`.A dictionary containing options for the Jinja2 template environment. This **only** applies to the **HTML/Markdown** content.
-    `nl2br`                | `#!py3 bool`           | `#!py3 True`  | Determines whether the newline to `#!html <br>` Python Markdown extension is enabled or not. Will be ignored if `markdown_extensions` is configured in YAML frontmatter.
-    `allow_code_wrap`      | `#!py3 bool`           | `#!py3 False` | Do not convert all the spaces in code blocks to `&nbsp;` so that wrapping can occur. YAML frontmatter's `allow_code_wrap` will always be used instead of this if specified.
 
-    !!! warning "Deprecation"
-        In 2.1.0 `nl2br` and `alow_code_wrap` are deprecated. The legacy parameters here will be dropped by 2018 for ST3 and these settings will not carry over to ST4.
+    !!! alert "Removed in 4.0"
+        4.0 removed the parameter `nl2br` and `alow_code_wrap`. If passed to the function, they will be ignored.
 
         To disable `nl2br`, you can customize which extensions get loaded; see [Configure Markdown Extensions](#configure-markdown-extensions).
 
@@ -373,8 +368,6 @@ MdPopups provides a number of accessible functions.
     `wrapper_class`        | `#!py3 str`            | `#!py3 None`  | A string containing the class name you wish wrap your content in.  A `div` will be created with the given class.
     `template_vars`        | `#!py3 dict`           | `#!py3 None`  | A dictionary containing template vars.  These can be used in either the CSS or the HTML/Markdown content.A dictionary containing template vars.  These can be used in either the CSS or the HTML/Markdown content. These vars are found under the object `plugin`.
     `template_env_options` | `#!py3 dict`           | `#!py3 None`  | A dictionary containing options for the Jinja2 template environment. This **only** applies to the **HTML/Markdown** content. Content plugin vars are found under the object: `plugin`.A dictionary containing options for the Jinja2 template environment. This **only** applies to the **HTML/Markdown** content.
-    `nl2br`                | `#!py3 bool`           | `#!py3 True`  | Determines whether the newline to `#!html <br>` Python Markdown extension is enabled or not. Will be ignored if `markdown_extensions` is configured in YAML frontmatter.
-    `allow_code_wrap`      | `#!py3 bool`           | `#!py3 False` | Do not convert all the spaces in code blocks to `&nbsp;` so that wrapping can occur. YAML frontmatter's `allow_code_wrap` will always be used instead of this if specified.
 
     **Attributes**
 
@@ -389,11 +382,9 @@ MdPopups provides a number of accessible functions.
     `wrapper_class`        | `#!py3 str`            | A string containing the class name you wish wrap your content in.  A `div` will be created with the given class.
     `template_vars`        | `#!py3 dict`           | A dictionary containing template vars.  These can be used in either the CSS or the HTML/Markdown content.A dictionary containing template vars.  These can be used in either the CSS or the HTML/Markdown content. These vars are found under the object `plugin`.
     `template_env_options` | `#!py3 dict`           | A dictionary containing options for the Jinja2 template environment. This **only** applies to the **HTML/Markdown** content. Content plugin vars are found under the object: `plugin`.A dictionary containing options for the Jinja2 template environment. This **only** applies to the **HTML/Markdown** content.
-    `nl2br`                | `#!py3 bool`           | `#!py3 True`  | Determines whether the newline to `#!html <br>` Python Markdown extension is enabled or not. Will be ignored if `markdown_extensions` is configured in YAML frontmatter.
-    `allow_code_wrap`      | `#!py3 bool`           | `#!py3 False` | Do not convert all the spaces in code blocks to `&nbsp;` so that wrapping can occur. YAML frontmatter's `allow_code_wrap` will always be used instead of this if specified.
 
-    !!! warning "Deprecation"
-        In 2.1.0 `nl2br` and `alow_code_wrap` are deprecated. The legacy parameters here will be dropped by 2018 for ST3 and these settings will not carry over to ST4.
+    !!! alert "Removed in 4.0"
+        4.0 removed the parameter `nl2br` and `alow_code_wrap`. If passed to the function, they will be ignored.
 
         To disable `nl2br`, you can customize which extensions get loaded; see [Configure Markdown Extensions](#configure-markdown-extensions).
 
@@ -441,11 +432,16 @@ MdPopups provides a number of accessible functions.
     `wrapper_class`        | `#!py3 str`                               | `#!py3 None`  | A string containing the class name you wish wrap your content in.  A `div` will be created with the given class.
     `template_vars`        | `#!py3 dict`                              | `#!py3 None`  | A dictionary containing template vars.  These can be used in either the CSS or the HTML/Markdown content. These vars are found under the object `plugin`.
     `template_env_options` | `#!py3 dict`                              | `#!py3 None`  | A dictionary containing options for the Jinja2 template environment. This **only** applies to the **HTML/Markdown** content.
-    `nl2br`                | `#!py3 bool`                              | `#!py3 True`  | Determines whether the newline to `#!html <br>` Python Markdown extension is enabled or not. Will be ignored if `markdown_extensions` is configured in YAML frontmatter.
-    `allow_code_wrap`      | `#!py3 bool`                              | `#!py3 False` | Do not convert all the spaces in code blocks to `&nbsp;` so that wrapping can occur. YAML frontmatter's `allow_code_wrap` will always be used instead of this if specified.
 
 !!! new "New 3.6.0"
     `new_html_sheet` is new in 3.6.0.
+
+!!! alert "Removed in 4.0"
+    4.0 removed the parameter `nl2br` and `alow_code_wrap`. If passed to the function, they will be ignored.
+
+    To disable `nl2br`, you can customize which extensions get loaded; see [Configure Markdown Extensions](#configure-markdown-extensions).
+
+    To enable code wrapping, see [Enable Code Wrapping](#enable-code-wrapping).
 
 ### Update HTML Content
 
@@ -465,11 +461,16 @@ MdPopups provides a number of accessible functions.
     `wrapper_class`        | `#!py3 str`                               | `#!py3 None`  | A string containing the class name you wish wrap your content in.  A `div` will be created with the given class.
     `template_vars`        | `#!py3 dict`                              | `#!py3 None`  | A dictionary containing template vars.  These can be used in either the CSS or the HTML/Markdown content. These vars are found under the object `plugin`.
     `template_env_options` | `#!py3 dict`                              | `#!py3 None`  | A dictionary containing options for the Jinja2 template environment. This **only** applies to the **HTML/Markdown** content.
-    `nl2br`                | `#!py3 bool`                              | `#!py3 True`  | Determines whether the newline to `#!html <br>` Python Markdown extension is enabled or not. Will be ignored if `markdown_extensions` is configured in YAML frontmatter.
-    `allow_code_wrap`      | `#!py3 bool`                              | `#!py3 False` | Do not convert all the spaces in code blocks to `&nbsp;` so that wrapping can occur. YAML frontmatter's `allow_code_wrap` will always be used instead of this if specified.
 
 !!! new "New 3.6.0"
     `new_html_sheet` is new in 3.6.0.
+
+!!! alert "Removed in 4.0"
+    4.0 removed the parameter `nl2br` and `alow_code_wrap`. If passed to the function, they will be ignored.
+
+    To disable `nl2br`, you can customize which extensions get loaded; see [Configure Markdown Extensions](#configure-markdown-extensions).
+
+    To enable code wrapping, see [Enable Code Wrapping](#enable-code-wrapping).
 
 ### Clear Cache
 
@@ -489,11 +490,9 @@ MdPopups provides a number of accessible functions.
     `markup`               | `#!py3 string`       | Yes          |               | The markup code to be converted.
     `template_vars`        | `#!py3 dict`         | No           | `#!py3 None`  | A dictionary containing template vars.  These can be used in either the CSS or the HTML/Markdown content.A dictionary containing template vars.  These can be used in either the CSS or the HTML/Markdown content. These vars are found under the object `plugin`.
     `template_env_options` | `#!py3 dict`         | No           | `#!py3 None`  | A dictionary containing options for the Jinja2 template environment. This **only** applies to the **HTML/Markdown** content. Content plugin vars are found under the object: `plugin`.A dictionary containing options for the Jinja2 template environment. This **only** applies to the **HTML/Markdown** content.
-    `nl2br`                | `#!py3 bool`         | `#!py3 True`  | Determines whether the newline to `#!html <br>` Python Markdown extension is enabled or not. Will be ignored if `markdown_extensions` is configured in YAML frontmatter.
-    `allow_code_wrap`      | `#!py3 bool`         | `#!py3 False` | Do not convert all the spaces in code blocks to `&nbsp;` so that wrapping can occur. YAML frontmatter's `allow_code_wrap` will always be used instead of this if specified.
 
-    !!! warning "Deprecation"
-        In 2.1.0 `nl2br` and `alow_code_wrap` are deprecated. The legacy parameters here will be dropped by 2018 for ST3 and these settings will not carry over to ST4.
+    !!! alert "Removed in 4.0"
+        4.0 removed the parameter `nl2br` and `alow_code_wrap`. If passed to the function, they will be ignored.
 
         To disable `nl2br`, you can customize which extensions get loaded; see [Configure Markdown Extensions](#configure-markdown-extensions).
 

--- a/docs/src/markdown/api.md
+++ b/docs/src/markdown/api.md
@@ -2,7 +2,8 @@
 
 ## Dependencies
 
-Your plugin should include the Package Control dependencies listed below. Please read about Package Control's [dependencies][pc-dependencies] to learn more.
+Your plugin should include the Package Control dependencies listed below. Please read about Package Control's
+[dependencies][pc-dependencies] to learn more.
 
 ```js
 {
@@ -27,23 +28,40 @@ the source HTML for debugging. Feel free to try it out.
 
 ## Markdown Support
 
-MdPopups uses @Python-Markdown/markdown to parse Markdown and transform it into a Sublime popup or phantom. The Markdown environment supports basic Markdown syntax, but also includes a number of specialty extensions to enhance and extend the Markdown environment.
+MdPopups uses @Python-Markdown/markdown to parse Markdown and transform it into a Sublime popup or phantom. The Markdown
+environment supports basic Markdown syntax, but also includes a number of specialty extensions to enhance and extend the
+Markdown environment.
 
-Due to the `minihtml` environment that Sublime uses, the type of tags and CSS that can be used are a bit limited. MdPopups provides a CSS that includes most of the common supported tags that can be used. Then few specific extensions (that work well within the `minihtml` environment) have been selected to provide support for a some additional useful features.
+Due to the `minihtml` environment that Sublime uses, the type of tags and CSS that can be used are a bit limited.
+MdPopups provides a CSS that includes most of the common supported tags that can be used. Then few specific extensions
+(that work well within the `minihtml` environment) have been selected to provide support for a some additional useful
+features.
 
-Prior to version 2.0.0, the default extensions and extension configurations were locked down, but starting with 2.1.0, this restriction has been mostly removed. Not all Python Markdown extensions and extension options are compatible with Sublime's `minihtml` environment, and extensions like `markdown.extensions.extra` can include some extensions that are not compatible, but there are a number of additional extension and extension options that can be used beyond what is provided by default. In general, it is recommended to include each plugin individual on a case by case basis and disable features that aren't compatible.
+Prior to version 2.0.0, the default extensions and extension configurations were locked down, but starting with 2.1.0,
+this restriction has been mostly removed. Not all Python Markdown extensions and extension options are compatible with
+Sublime's `minihtml` environment, and extensions like `markdown.extensions.extra` can include some extensions that are
+not compatible, but there are a number of additional extension and extension options that can be used beyond what is
+provided by default. In general, it is recommended to include each plugin individual on a case by case basis and disable
+features that aren't compatible.
 
-Below we will touch on the specific extensions used by default which are known to work in the Sublime `minihtml` environment. If you are on version 2.1.0+, read on in [Frontmatter](#frontmatter) to learn how to customize extensions.
+Below we will touch on the specific extensions used by default which are known to work in the Sublime `minihtml`
+environment. If you are on version 2.1.0+, read on in [Frontmatter](#frontmatter) to learn how to customize extensions.
 
 ### Extensions
 
-These three extensions are setup and configured automatically and should not be configured manually. Also, do not try to use `markdown.extensions.codehilite` or `markdown.extensions.fenced_code` as the following extensions have been specifically altered to output Sublime syntax highlighting properly and will clash with `markdown.extensions.codehilite` and `markdown.extensions.fenced_code`.
+These three extensions are setup and configured automatically and should not be configured manually. Also, do not try to
+use `markdown.extensions.codehilite` or `markdown.extensions.fenced_code` as the following extensions have been
+specifically altered to output Sublime syntax highlighting properly and will clash with `markdown.extensions.codehilite`
+and `markdown.extensions.fenced_code`.
 
-- `mdpopups.mdx.highlight` ( a modified version [`pymdownx.highlight`][highlight] for Sublime Text highlighting) controls and configures the highlighting of code blocks.
+- `mdpopups.mdx.highlight` ( a modified version [`pymdownx.highlight`][highlight] for Sublime Text highlighting)
+  controls and configures the highlighting of code blocks.
 
-- `mdpopups.mdx.superfences` (a modified version [`pymdownx.superfences`][superfences] for Sublime Text highlighting) that provides support for nested fenced blocks.
+- `mdpopups.mdx.superfences` (a modified version [`pymdownx.superfences`][superfences] for Sublime Text highlighting)
+  that provides support for nested fenced blocks.
 
-- `mdpopups.mdx.inlinehilite` (a modified version of [`pymdownx.inlinehilite`] for Sublime Text highlighting) allows for inline code highlighting: `` `#!py3thon import module` `` --> `#!py3thon import module`. Please don't use this version.
+- `mdpopups.mdx.inlinehilite` (a modified version of [`pymdownx.inlinehilite`] for Sublime Text highlighting) allows for
+  inline code highlighting: `` `#!py3thon import module` `` --> `#!py3thon import module`. Please don't use this version.
 
 These extensions are provided by Python Markdown:
 
@@ -57,15 +75,25 @@ These extensions are provided by Python Markdown:
 
 These are 3rd party extensions provided by PyMdown Extensions:
 
-- [`pymdownx.betterem`][betterem] is an extension that aims to improve upon emphasis support in Python Markdown. MdPopups leaves it configured in its default state where underscores are handled intelligently: `_handled_intelligently_` --> _handled_intelligently_ and asterisks can be used to do mid word emphasis: `em*pha*sis` --> em*pha*sis.
+- [`pymdownx.betterem`][betterem] is an extension that aims to improve upon emphasis support in Python Markdown.
+  MdPopups leaves it configured in its default state where underscores are handled intelligently:
+  `_handled_intelligently_` --> _handled_intelligently_ and asterisks can be used to do mid word emphasis: `em*pha*sis`
+  --> em*pha*sis.
 
-- [`pymdownx.magiclink`][magiclink] auto links HTML and email links.  In `2.1.0`+, it also allows the shortening of common repository pull request, issue, and commit links (if configured).
+- [`pymdownx.magiclink`][magiclink] auto links HTML and email links.  In `2.1.0`+, it also allows the shortening of
+  common repository pull request, issue, and commit links (if configured).
 
-- [`pymdownx.extrarawhtml`][extrarawhtml] allows you to add `markdown="1"` to raw, block HTML elements to allow content under them to be parsed with Python markdown (inline tags should already have their content parsed).  This module is exposing *just* this functionality from the [Python Markdown's Extra extension](https://pythonhosted.org/Markdown/extensions/extra.html#nested-markdown-inside-html-blocks) as the feature could not be enabled without including all of the `Extra` extensions other features.  You can read the Python Markdown's Extra extension documentation to learn more about this feature.
+- [`pymdownx.extrarawhtml`][extrarawhtml] allows you to add `markdown="1"` to raw, block HTML elements to allow content
+  under them to be parsed with Python markdown (inline tags should already have their content parsed).  This module is
+  exposing *just* this functionality from the [Python Markdown's Extra extension][md_in_html] as the feature could not
+  be enabled without including all of the `Extra` extensions other features.  You can read the Python Markdown's Extra
+  extension documentation to learn more about this feature.
 
 ## Frontmatter
 
-Frontmatter can be used to configure content in 2.1.0+. The frontmatter must be specified, starting on the first line of the content, before the Markdown.  The frontmatter content should be in YAML syntax and should come between the YAML markers: `---`.
+Frontmatter can be used to configure content in 2.1.0+. The frontmatter must be specified, starting on the first line of
+the content, before the Markdown.  The frontmatter content should be in YAML syntax and should come between the YAML
+markers: `---`.
 
 ```yaml
 ---
@@ -92,7 +120,8 @@ key2: value2
 
 ### Enable Code Wrapping
 
-The `allow_code_wrap` setting allows block code tags to have their content wrapped. If disabled (the default), code content will not wrap lines.
+The `allow_code_wrap` setting allows block code tags to have their content wrapped. If disabled (the default), code
+content will not wrap lines.
 
 ```yaml
 ---
@@ -102,7 +131,10 @@ allow_code_wrap: true
 
 ### Custom Fences
 
-The included `mdpopups.mdx.superfences` has an option that allows for custom fences. Custom fences are a convenient way to add support for special block content such as UML diagrams. Since configuring `mdpopups.mdx.superfences` is not allowed directly, you can setup your own custom fences via a separate `custom_fences` option. See the original SuperFences' [Custom Fences][custom-fences] documentation to learn more.
+The included `mdpopups.mdx.superfences` has an option that allows for custom fences. Custom fences are a convenient way
+to add support for special block content such as UML diagrams. Since configuring `mdpopups.mdx.superfences` is not
+allowed directly, you can setup your own custom fences via a separate `custom_fences` option. See the original
+SuperFences' [Custom Fences][custom-fences] documentation to learn more.
 
 ```yaml
 ---
@@ -115,7 +147,10 @@ custom_fences:
 
 ### Configure Markdown Extensions
 
-Custom extension configurations are specified under the `markdown_extensions` key whose value is an array of extensions. Each extension is specified as a string.  If you have specific settings to configure for an extension, simply make that array entry a dictionary where the key name is the extension name, and value is a hash table with all the settings.  The default configuration is below.
+Custom extension configurations are specified under the `markdown_extensions` key whose value is an array of extensions.
+Each extension is specified as a string.  If you have specific settings to configure for an extension, simply make that
+array entry a dictionary where the key name is the extension name, and value is a hash table with all the settings.
+The default configuration is below.
 
 ```yaml
 ---
@@ -130,9 +165,13 @@ markdown_extensions:
 ...
 ```
 
-Notice that `mdpopups.mdx.highlight`, `mdpopups.mdx.superfences`, and `mdpopups.mdx.inlinehilite` are not shown here as they cannot be set directly and are handled by automatically by MdPopups.
+Notice that `mdpopups.mdx.highlight`, `mdpopups.mdx.superfences`, and `mdpopups.mdx.inlinehilite` are not shown here as
+they cannot be set directly and are handled by automatically by MdPopups.
 
-Let's say we wanted to keep the default extensions, but we wanted to enable `pymdown.magiclink`'s repository URL shortening and add and configure `pymdownx.keys`, `pymdownx.escapeall`, `pymdownx.smartsymbols`, and `markdown.extensions.smarty`. We must specify the full configuration we would like. We will use the base default settings outlined above, adding our new options and extensions.
+Let's say we wanted to keep the default extensions, but we wanted to enable `pymdown.magiclink`'s repository URL
+shortening and add and configure `pymdownx.keys`, `pymdownx.escapeall`, `pymdownx.smartsymbols`, and
+`markdown.extensions.smarty`. We must specify the full configuration we would like. We will use the base default
+settings outlined above, adding our new options and extensions.
 
 ```yaml
 ---
@@ -159,7 +198,8 @@ markdown_extensions:
 
 ### Configure Frontmatter From Python Objects
 
-A lot of times in plugins, it may be easier to build up a Python dictionary and convert it to YAML.  MdPopups provides a function to exactly this:
+A lot of times in plugins, it may be easier to build up a Python dictionary and convert it to YAML.  MdPopups provides a
+function to exactly this:
 
 ```py3
 frontmatter = {
@@ -191,11 +231,18 @@ content = mdpopups.format_frontmatter(frontmatter) + markdown_content
 
 ## Styling
 
-Popups and phantoms are styled with CSS that is fed through the Jinja2 template engine. A default CSS is provided that styles commonly used elements. Plugins can provide CSS to add additional styling for plugin specific purposes. See [CSS Styling](./styling.md) to learn more about the template engine and general styling info.
+Popups and phantoms are styled with CSS that is fed through the Jinja2 template engine. A default CSS is provided that
+styles commonly used elements. Plugins can provide CSS to add additional styling for plugin specific purposes. See
+[CSS Styling](./styling.md) to learn more about the template engine and general styling info.
 
-It is advised to use the `wrapper_class` option of the `show_popup`, `update_popup`, and `add_phantom` commands to wrap your plugin content in a div with a unique, plugin specific class.  This way plugins can inject CSS to style their specific elements via `#!css .mdpopups .myplugin-wrapper .myclass {}` or simply `#!css .myplugin-wrapper .myclass {}`.
+It is advised to use the `wrapper_class` option of the `show_popup`, `update_popup`, and `add_phantom` commands to wrap
+your plugin content in a div with a unique, plugin specific class.  This way plugins can inject CSS to style their
+specific elements via `#!css .mdpopups .myplugin-wrapper .myclass {}` or simply `#!css .myplugin-wrapper .myclass {}`.
 
-Also check out the included Python Markdown [`attr_list` extension syntax](https://pythonhosted.org/Markdown/extensions/attr_list.html). This is a good extension for applying classes directly to elements within Markdown format. Sometimes it can be difficult to target certain kinds of block elements, so if all else fails, you can insert raw HTML for specific elements into your Markdown and apply classes directly to them.
+Also check out the included Python Markdown [`attr_list` extension syntax][attr_list]. This is a good extension for
+applying classes directly to elements within Markdown format. Sometimes it can be difficult to target certain kinds of
+block elements, so if all else fails, you can insert raw HTML for specific elements into your Markdown and apply classes
+directly to them.
 
 ## API Usage
 
@@ -205,13 +252,15 @@ MdPopups provides a number of accessible functions.
 
 `#!py3 (int,) mdpopups.version`
 : 
-    Returns the version of the MdPopups library.  Returns a tuple of integers which represents the major, minor, and patch version.
+    Returns the version of the MdPopups library.  Returns a tuple of integers which represents the major, minor, and
+    patch version.
 
 ### Show Popup
 
 `#!py3 mdpopups.show_popup`
 : 
-    Accepts Markdown and creates a Sublime popup.  By default, the built-in Sublime syntax highlighter will be used for code highlighting.
+    Accepts Markdown and creates a Sublime popup.  By default, the built-in Sublime syntax highlighter will be used for
+    code highlighting.
 
     Parameter              | Type                 | Default       | Description
     ---------------------- | -------------------- | ------------- | -----------
@@ -232,7 +281,8 @@ MdPopups provides a number of accessible functions.
     !!! alert "Removed in 4.0"
         4.0 removed the parameter `nl2br` and `alow_code_wrap`. If passed to the function, they will be ignored.
 
-        To disable `nl2br`, you can customize which extensions get loaded; see [Configure Markdown Extensions](#configure-markdown-extensions).
+        To disable `nl2br`, you can customize which extensions get loaded; see
+        [Configure Markdown Extensions](#configure-markdown-extensions).
 
         To enable code wrapping, see [Enable Code Wrapping](#enable-code-wrapping).
 
@@ -255,7 +305,8 @@ MdPopups provides a number of accessible functions.
     !!! alert "Removed in 4.0"
         4.0 removed the parameter `nl2br` and `alow_code_wrap`. If passed to the function, they will be ignored.
 
-        To disable `nl2br`, you can customize which extensions get loaded; see [Configure Markdown Extensions](#configure-markdown-extensions).
+        To disable `nl2br`, you can customize which extensions get loaded; see
+        [Configure Markdown Extensions](#configure-markdown-extensions).
 
         To enable code wrapping, see [Enable Code Wrapping](#enable-code-wrapping).
 
@@ -284,7 +335,8 @@ MdPopups provides a number of accessible functions.
 
 `#!py3 int mdpopups.add_phantom`
 : 
-    Adds a phantom to the view and returns the phantom id as an integer. By default, the built-in Sublime syntax highlighter will be used for code highlighting. 
+    Adds a phantom to the view and returns the phantom id as an integer. By default, the built-in Sublime syntax
+    highlighter will be used for code highlighting.
 
     Parameter              | Type                   | Default       | Description
     ---------------------- | ---------------------- | ------------- | -----------
@@ -303,7 +355,8 @@ MdPopups provides a number of accessible functions.
     !!! alert "Removed in 4.0"
         4.0 removed the parameter `nl2br` and `alow_code_wrap`. If passed to the function, they will be ignored.
 
-        To disable `nl2br`, you can customize which extensions get loaded; see [Configure Markdown Extensions](#configure-markdown-extensions).
+        To disable `nl2br`, you can customize which extensions get loaded; see
+        [Configure Markdown Extensions](#configure-markdown-extensions).
 
         To enable code wrapping, see [Enable Code Wrapping](#enable-code-wrapping).
 
@@ -333,7 +386,9 @@ MdPopups provides a number of accessible functions.
 
 `#!py3 [sublime.Region] mdpopups.query_phantom`
 : 
-    Query the location of a phantom by specifying its id.  A list of `sublime.Region`s will be returned.  If the phantom with the given id is not found, the region will be returned with positions of `(-1, -1)`.  Included for convenience and consistency.
+    Query the location of a phantom by specifying its id.  A list of `sublime.Region`s will be returned.  If the phantom
+    with the given id is not found, the region will be returned with positions of `(-1, -1)`.  Included for convenience
+    and consistency.
 
     Parameter | Type                 | Default | Description
     --------- | -------------------- | ------- | -----------
@@ -344,7 +399,9 @@ MdPopups provides a number of accessible functions.
 
 `#!py3 [sublime.Region] mdpopups.query_phantoms`
 : 
-    Query the location of multiple phantoms by specifying their ids.  A list of `sublime.Region`s will be returned where each index corresponds to the index of ids that was passed in.  If a given phantom id is not found, that region will be returned with positions of `(-1, -1)`.  Included for convenience and consistency.
+    Query the location of multiple phantoms by specifying their ids.  A list of `sublime.Region`s will be returned where
+    each index corresponds to the index of ids that was passed in.  If a given phantom id is not found, that region will
+    be returned with positions of `(-1, -1)`.  Included for convenience and consistency.
 
     Parameter | Type                 | Default | Description
     --------- | -------------------- | ------- | -----------
@@ -386,7 +443,8 @@ MdPopups provides a number of accessible functions.
     !!! alert "Removed in 4.0"
         4.0 removed the parameter `nl2br` and `alow_code_wrap`. If passed to the function, they will be ignored.
 
-        To disable `nl2br`, you can customize which extensions get loaded; see [Configure Markdown Extensions](#configure-markdown-extensions).
+        To disable `nl2br`, you can customize which extensions get loaded; see
+        [Configure Markdown Extensions](#configure-markdown-extensions).
 
         To enable code wrapping, see [Enable Code Wrapping](#enable-code-wrapping).
 
@@ -414,11 +472,13 @@ MdPopups provides a number of accessible functions.
 ### New HTML Sheet
 
 !!! warning "Experimental Feature"
-    This feature is new in Sublime Text 4. Sublime's API may change in future versions for this feature and may break this.
+    This feature is new in Sublime Text 4. Sublime's API may change in future versions for this feature and may break
+    this.
 
 `#!py3 mdpopups.new_html_sheet`
 : 
-    Accepts Markdown and creates a Sublime HTML sheet.  By default, the built-in Sublime syntax highlighter will be used for code highlighting.
+    Accepts Markdown and creates a Sublime HTML sheet.  By default, the built-in Sublime syntax highlighter will be used
+    for code highlighting.
 
     Parameter              | Type                                      | Default       | Description
     ---------------------- | ----------------------------------------- | ------------- | -----------
@@ -439,7 +499,8 @@ MdPopups provides a number of accessible functions.
 !!! alert "Removed in 4.0"
     4.0 removed the parameter `nl2br` and `alow_code_wrap`. If passed to the function, they will be ignored.
 
-    To disable `nl2br`, you can customize which extensions get loaded; see [Configure Markdown Extensions](#configure-markdown-extensions).
+    To disable `nl2br`, you can customize which extensions get loaded; see
+    [Configure Markdown Extensions](#configure-markdown-extensions).
 
     To enable code wrapping, see [Enable Code Wrapping](#enable-code-wrapping).
 
@@ -450,7 +511,8 @@ MdPopups provides a number of accessible functions.
 
 `#!py3 mdpopups.update_html_sheet`
 : 
-    Accepts Markdown and updates the content of a Sublime HTML sheet.  By default, the built-in Sublime syntax highlighter will be used for code highlighting.
+    Accepts Markdown and updates the content of a Sublime HTML sheet.  By default, the built-in Sublime syntax
+    highlighter will be used for code highlighting.
 
     Parameter              | Type                                      | Default       | Description
     ---------------------- | ----------------------------------------- | ------------- | -----------
@@ -468,7 +530,8 @@ MdPopups provides a number of accessible functions.
 !!! alert "Removed in 4.0"
     4.0 removed the parameter `nl2br` and `alow_code_wrap`. If passed to the function, they will be ignored.
 
-    To disable `nl2br`, you can customize which extensions get loaded; see [Configure Markdown Extensions](#configure-markdown-extensions).
+    To disable `nl2br`, you can customize which extensions get loaded; see
+    [Configure Markdown Extensions](#configure-markdown-extensions).
 
     To enable code wrapping, see [Enable Code Wrapping](#enable-code-wrapping).
 
@@ -482,7 +545,10 @@ MdPopups provides a number of accessible functions.
 
 `#!py3 str mdpopups.md2html`
 : 
-    Exposes the Markdown to HTML converter in case it is desired to parse only a section of markdown.  This works well for someone who wants to work directly in HTML, but might want to still have fragments of markdown that they would like to occasionally convert. By default, the built-in Sublime syntax highlighter will be used for code highlighting.
+    Exposes the Markdown to HTML converter in case it is desired to parse only a section of markdown.  This works well
+    for someone who wants to work directly in HTML, but might want to still have fragments of markdown that they would
+    like to occasionally convert. By default, the built-in Sublime syntax highlighter will be used for code
+    highlighting.
 
     Parameter              | Type                 | Required     | Default       | Description
     ---------------------- | -------------------- | ------------ | ------------- | -----------
@@ -494,7 +560,8 @@ MdPopups provides a number of accessible functions.
     !!! alert "Removed in 4.0"
         4.0 removed the parameter `nl2br` and `alow_code_wrap`. If passed to the function, they will be ignored.
 
-        To disable `nl2br`, you can customize which extensions get loaded; see [Configure Markdown Extensions](#configure-markdown-extensions).
+        To disable `nl2br`, you can customize which extensions get loaded; see
+        [Configure Markdown Extensions](#configure-markdown-extensions).
 
         To enable code wrapping, see [Enable Code Wrapping](#enable-code-wrapping).
 
@@ -502,7 +569,8 @@ MdPopups provides a number of accessible functions.
 
 `#!py3 str mdpopups.color_box`
 : 
-    Generates a color preview box image encoded in base 64 and formatted to be inserted right in your your Markdown or HTML code as an `img` tag.
+    Generates a color preview box image encoded in base 64 and formatted to be inserted right in your your Markdown or
+    HTML code as an `img` tag.
 
     Parameter     | Type          | Default       | Description
     ------------- | ------------- | ------------- | -----------
@@ -540,7 +608,8 @@ MdPopups provides a number of accessible functions.
 
 `#!py3 str mdpopups.tint`
 : 
-    Takes a either a path to an PNG or a byte string of a PNG and tints it with a specific color and returns a string containing the base 64 encoded PNG in a HTML element.
+    Takes a either a path to an PNG or a byte string of a PNG and tints it with a specific color and returns a string
+    containing the base 64 encoded PNG in a HTML element.
 
     Parameter | Type              | Default      | Description
     --------- | ----------------- | ------------ | -----------
@@ -554,7 +623,8 @@ MdPopups provides a number of accessible functions.
 
 `#!py3 bytes mdpopups.tint_raw`
 : 
-    Takes a either a path to an PNG or a byte string of a PNG and tints it with a specific color and returns a byte string of the modified PNG.
+    Takes a either a path to an PNG or a byte string of a PNG and tints it with a specific color and returns a byte
+    string of the modified PNG.
 
     Parameter | Type              | Default     | Description
     --------- | ----------------- | ----------- | -----------
@@ -566,7 +636,9 @@ MdPopups provides a number of accessible functions.
 
 `#!py3 dict mdpopups.scope2style`
 : 
-    Takes a sublime scope (complexity doesn't matter), and guesses the style that would be applied.  While there may be untested corner cases with complex scopes where it fails, in general, it is usually accurate.  The returned dictionary is in the form:
+    Takes a sublime scope (complexity doesn't matter), and guesses the style that would be applied.  While there may be
+    untested corner cases with complex scopes where it fails, in general, it is usually accurate.  The returned
+    dictionary is in the form:
 
     ```py3
     {
@@ -596,7 +668,9 @@ MdPopups provides a number of accessible functions.
 
 `#!py3 str mdpopups.syntax_highlight`
 : 
-    Allows for syntax highlighting outside the Markdown environment.  You can just feed it code directly and give it the language of your choice, and you will be returned a block of HTML that has been syntax highlighted. By default, the built-in Sublime syntax highlighter will be used for code highlighting.
+    Allows for syntax highlighting outside the Markdown environment.  You can just feed it code directly and give it the
+    language of your choice, and you will be returned a block of HTML that has been syntax highlighted. By default, the
+    built-in Sublime syntax highlighter will be used for code highlighting.
 
     Parameter         | Type                 | Default       | Description
     ----------------- | -------------------- | ------------- | -----------
@@ -610,9 +684,16 @@ MdPopups provides a number of accessible functions.
 
 `#!py3 str mdpopups.tabs2spaces`
 : 
-    The Markdown parser used converts all tabs to spaces with the simple logic of 1 tab equals 4 spaces. This logic is generally applied in other places like [`syntax_highlight`](#syntax-highlight). When formatting code for `syntax_highlight`, you may want to translate the tabs to spaces based on tab stops *before* passing it through opposed to apply the simple logic of converting all tabs to 4 spaces regardless of tab stops. `tabs2spaces` does exactly this, allowing you format the whitespace in a more intelligent manner.
+    The Markdown parser used converts all tabs to spaces with the simple logic of 1 tab equals 4 spaces. This logic is
+    generally applied in other places like [`syntax_highlight`](#syntax-highlight). When formatting code for
+    `syntax_highlight`, you may want to translate the tabs to spaces based on tab stops *before* passing it through
+    opposed to apply the simple logic of converting all tabs to 4 spaces regardless of tab stops. `tabs2spaces` does
+    exactly this, allowing you format the whitespace in a more intelligent manner.
 
-    `tabs2spaces` cannot do anything about characters, and there are some even in monospace fonts, that are wider than normal characters. It doesn't detect zero width characters either. It also cannot predict cases where two or more Unicode character are shown as one. But in some cases, this more intelligent output is much better than the "all tabs are arbitrarily one size" logic.
+    `tabs2spaces` cannot do anything about characters, and there are some even in monospace fonts, that are wider than
+    normal characters. It doesn't detect zero width characters either. It also cannot predict cases where two or more
+    Unicode character are shown as one. But in some cases, this more intelligent output is much better than the "all
+    tabs are arbitrarily one size" logic.
 
     Example (Notice that `♭` is a bit larger than normal characters):
 
@@ -645,7 +726,8 @@ MdPopups provides a number of accessible functions.
 
 `#!py3 str mdpopups.get_language_from_view`
 : 
-    Allows a user to extract the equivalent language specifier for `mdpopups.syntax_highlight` from a view.  If the language cannot be determined, `None` will be returned.
+    Allows a user to extract the equivalent language specifier for `mdpopups.syntax_highlight` from a view.  If the
+    language cannot be determined, `None` will be returned.
 
     Parameter | Type                 | Default | Description
     --------- | -------------------- | ------- | -----------

--- a/docs/src/markdown/faq.md
+++ b/docs/src/markdown/faq.md
@@ -4,15 +4,24 @@
 
 - **Why don't `#!html <pre>` tags work right when I do them, but MdPopups' work correctly?**
 
-    This is because the HTML engine in Sublime treats `#!html <pre>` tags just as a normal block elements; it doesn't treat the content as preformatted.  When MdPopups creates code blocks, it actually does a lot of special formatting to the blocks.  It converts tabs to 4 spaces, and spaces are converted to `#!html &nbsp;` to prevent wrapping.  Lastly, new lines get converted to `#!html <br>` tags.
+    This is because the HTML engine in Sublime treats `#!html <pre>` tags just as a normal block elements; it doesn't
+    treat the content as preformatted.  When MdPopups creates code blocks, it actually does a lot of special formatting
+    to the blocks.  It converts tabs to 4 spaces, and spaces are converted to `#!html &nbsp;` to prevent wrapping.
+    Lastly, new lines get converted to `#!html <br>` tags.
     {: style="font-style: italic"}
 
 - **Why in code blocks do tabs get converted to 4 spaces?**
 
-    Because I like it that way.  If you are planning on having a snippet of text sent through the syntax highlighter and do not want your tabs to be converted to 4 spaces, you should convert it to the number of spaces you like **before** sending it through the syntax highlighter.
+    Because I like it that way.  If you are planning on having a snippet of text sent through the syntax highlighter and
+    do not want your tabs to be converted to 4 spaces, you should convert it to the number of spaces you like **before**
+    sending it through the syntax highlighter.
     {: style="font-style: italic"}
 
 - **Why does &lt;insert element&gt; not work, or cause the popup/phantom not to show?**
 
-    Because Sublime's HTML engine is extremely limited or the element you are trying to use hasn't been styled correctly yet. Though I do not have a complete list of all supported elements, you can check out the provided `default.css` on the repository to see what is supported. There are probably some elements you could style and then would work correctly, but there are others like `#!html <table>` will not *currently* work. In general, you should keep things basic, but feel free to experiment to get an understanding of Sublime's `minihtml` engine limitations.
+    Because Sublime's HTML engine is extremely limited or the element you are trying to use hasn't been styled correctly
+    yet. Though I do not have a complete list of all supported elements, you can check out the provided `default.css` on
+    the repository to see what is supported. There are probably some elements you could style and then would work
+    correctly, but there are others like `#!html <table>` will not *currently* work. In general, you should keep things
+    basic, but feel free to experiment to get an understanding of Sublime's `minihtml` engine limitations.
     {: style="font-style: italic"}

--- a/docs/src/markdown/index.md
+++ b/docs/src/markdown/index.md
@@ -2,7 +2,10 @@
 
 ## Overview
 
-Sublime Markdown Popups (MdPopups) is a library for Sublime Text plugins.  It utilizes the new plugin API found in ST3 Beta to create popups and phantoms from Markdown or HTML. It requires at least ST3 3124+. MdPopups utilizes Python Markdown with a couple of special extensions to convert Markdown to HTML that can be used to create popups and/or phantoms.  It also provides a number of other helpful API commands to aid in creating great popups and phantoms.
+Sublime Markdown Popups (MdPopups) is a library for Sublime Text plugins.  It utilizes the new plugin API found in ST3
+to create popups and phantoms from Markdown or HTML. It requires at least ST3 3124+. MdPopups utilizes Python Markdown
+with a couple of special extensions to convert Markdown to HTML that can be used to create popups and/or phantoms.  It
+also provides a number of other helpful API commands to aid in creating great popups and phantoms.
 
 MdPopups will use your color scheme to create popups/phantoms that fit your editors look.
 
@@ -21,7 +24,9 @@ MdPopups will use your color scheme to create popups/phantoms that fit your edit
 
 - Can take Markdown or HTML and create nice looking popups and phantoms.
 - Dynamically creates popup and phantom themes from your current Sublime color scheme.
-- Can create syntax highlighted code blocks easily using your existing Sublime color scheme (can also use Pygments with some setup).
+- Can create syntax highlighted code blocks easily using your existing Sublime color scheme (can also use Pygments with
+  some setup).
 - Can create color preview boxes via API calls.
-- A CSS template environment that allows users to override and tweak the overall look of the popups and phantoms to better fit their preferred look.
+- A CSS template environment that allows users to override and tweak the overall look of the popups and phantoms to
+  better fit their preferred look.
 - Plugins can extend the current CSS to inject plugin specific class styling.

--- a/docs/src/markdown/installation.md
+++ b/docs/src/markdown/installation.md
@@ -2,9 +2,14 @@
 
 ## Package Control
 
-In order for your plugin to utilize Markdown Popups, you must be using [Package Control][package-control], and you must add `mdpopups` (and other related dependencies) as a dependency for your plugin.  This can be done in one of two ways, both of which are [documented][pc-dependencies] by Package Control; see **Using Dependencies**.  Package Control will install and update the dependency for you.  Package Control will also ensure that `mdpopups` is loaded before your plugin loads.
+In order for your plugin to utilize Markdown Popups, you must be using [Package Control][package-control], and you must
+add `mdpopups` (and other related dependencies) as a dependency for your plugin.  This can be done in one of two ways,
+both of which are [documented][pc-dependencies] by Package Control; see **Using Dependencies**.  Package Control will
+install and update the dependency for you.  Package Control will also ensure that `mdpopups` is loaded before your
+plugin loads.
 
-If ever you are on a older version than is currently released, and Package Control has not updated to the latest, you can force the update by running the `Package Control: Satisfy Dependencies` command from the command palette.
+If ever you are on a older version than is currently released, and Package Control has not updated to the latest, you
+can force the update by running the `Package Control: Satisfy Dependencies` command from the command palette.
 
 Remember, MdPopups is for Sublime Text 3 builds 3124+.
 

--- a/docs/src/markdown/settings.md
+++ b/docs/src/markdown/settings.md
@@ -2,11 +2,15 @@
 
 ## Configuring MdPopups
 
-All settings for MdPopups are placed in Sublime's `Preferences.sublime-settings`.  They are applied globally and to all popups and phantoms.
+All settings for MdPopups are placed in Sublime's `Preferences.sublime-settings`.  They are applied globally and to all
+popups and phantoms.
 
 ## `mdpopups.debug`
 
-Turns on debug mode.  This will dump out all sorts of info to the console.  Content before parsing to HTML, final HTML output, traceback from failures, etc..  This is more useful for plugin developers.  It works by specifying an error level.  `0` or `false` would disable it.  1 would trigger on errors. 2 would trigger on warnings and any level below.  3 would be general info (like HTML output) and any level below.
+Turns on debug mode.  This will dump out all sorts of info to the console.  Content before parsing to HTML, final HTML
+output, traceback from failures, etc..  This is more useful for plugin developers.  It works by specifying an error
+level.  `0` or `false` would disable it.  `1` would trigger on errors. `2` would trigger on warnings and any level
+below. `3` would be general info (like HTML output) and any level below.
 
 ```js
     "mdpopups.debug": 1,
@@ -22,7 +26,8 @@ Global kill switch to prevent popups (created by MdPopups) from appearing.
 
 ## `mdpopups.cache_refresh_time`
 
-Control how long a CSS theme file will be in the cache before being refreshed.  Value should be a positive integer greater than 0.  Units are in minutes.  Default is 30.
+Control how long a CSS theme file will be in the cache before being refreshed.  Value should be a positive integer
+greater than `0`.  Units are in minutes.  Default is `30`.
 
 ```js
     "mdpopups.cache_refresh_time": 30,
@@ -30,7 +35,8 @@ Control how long a CSS theme file will be in the cache before being refreshed.  
 
 ## `mdpopups.cache_limit`
 
-Control how many CSS theme files will be kept in cache at any given time.  Value should be a positive integer greater than or equal to 0.
+Control how many CSS theme files will be kept in cache at any given time.  Value should be a positive integer greater
+than or equal to `0`.
 
 ```js
     "mdpopups.cache_limit": 10
@@ -38,7 +44,10 @@ Control how many CSS theme files will be kept in cache at any given time.  Value
 
 ## `mdpopups.use_sublime_highlighter`
 
-Controls whether the Pygments or the native Sublime syntax highlighter is used for code highlighting.  This affects code highlighting in Markdown conversion and when code is directly processed using [syntax_highlight](./api.md#syntax-highlight). To learn more about the syntax highlighter see [Syntax Highlighting](./styling.md#syntax-highlighting).
+Controls whether the Pygments or the native Sublime syntax highlighter is used for code highlighting.  This affects code
+highlighting in Markdown conversion and when code is directly processed using
+[syntax_highlight](./api.md#syntax-highlight). To learn more about the syntax highlighter see
+[Syntax Highlighting](./styling.md#syntax-highlighting).
 
 ```js
     "mdpopups.use_sublime_highlighter": true
@@ -46,7 +55,9 @@ Controls whether the Pygments or the native Sublime syntax highlighter is used f
 
 ## `mdpopups.user_css`
 
-Overrides the default CSS and/or CSS of a plugin.  Value should be a relative path pointing to the CSS file: `Packages/User/my_custom_theme.css`.  Slashes should be forward slashes. By default, it will point to `Packages/User/mdpopups.css`.  User CSS overrides **all** CSS as it is the last to be processed.
+Overrides the default CSS and/or CSS of a plugin.  Value should be a relative path pointing to the CSS file:
+`Packages/User/my_custom_theme.css`.  Slashes should be forward slashes. By default, it will point to
+`Packages/User/mdpopups.css`.  User CSS overrides **all** CSS as it is the last to be processed.
 
 ```js
     "mdpopups.user_css": "Packages/User/mdpopups.css"
@@ -58,7 +69,10 @@ Controls whether MdPopups' default styling (contained in [`default.css`][default
 
 ## `mdpopups.sublime_user_lang_map`
 
-This setting is for the Sublime Syntax Highlighter and allows the mapping of personal Sublime syntax languages which are not yet included, or will not be included, in the official mapping table.  You can either define your own new entry, or use the same language name of an existing entry to extend the language `mapping_alias` or syntax languages.  When extending, the user mappings will be cycled through first.
+This setting is for the Sublime Syntax Highlighter and allows the mapping of personal Sublime syntax languages which are
+not yet included, or will not be included, in the official mapping table.  You can either define your own new entry, or
+use the same language name of an existing entry to extend the language `mapping_alias` or syntax languages.  When
+extending, the user mappings will be cycled through first.
 
 ```js
     "mdpopups.sublime_user_lang_map": {
@@ -76,7 +90,9 @@ This setting is for the Sublime Syntax Highlighter and allows the mapping of per
 For a list of all currently supported syntax mappings, see the official [mapping file][language-map].
 
 !!! tip "Tip"
-    When submitting new languages to the mapping table, it is encouraged to pick key names that correspond to what is used in Pygments so a User can switch between Pygments' and Sublime's syntax highlighter and still get highlighting.
+    When submitting new languages to the mapping table, it is encouraged to pick key names that correspond to what is
+    used in Pygments so a User can switch between Pygments' and Sublime's syntax highlighter and still get
+    highlighting.
 
 ## `mdpopups.legacy_color_matcher`
 

--- a/docs/src/markdown/styling.md
+++ b/docs/src/markdown/styling.md
@@ -2,17 +2,28 @@
 
 ## Syntax Highlighting
 
-MdPopups has two syntax highlighting methods: the native Sublime syntax highlighter (default) and Pygments.  When developing a plugin, it is wise to test out both. The native Sublime Syntax Highlighter has most default languages mapped along with a few others.
+MdPopups has two syntax highlighting methods: the native Sublime syntax highlighter (default) and Pygments.  When
+developing a plugin, it is wise to test out both. The native Sublime Syntax Highlighter has most default languages
+mapped along with a few others.
 
 ### Sublime Syntax Highlighter
 
-As previously mentioned, MdPopups uses the internal syntax highlighter to highlight your code.  The benefit here is that you get code highlighting in your popup that matches your current theme.  The highlighting ability is dependent upon what syntax packages you have installed in Sublime.  It also depends on whether that syntax is enabled and mapped to a language keyword.  Pull requests are welcome to expand and keep the [language mapping][language-map] updated.  You can also define in your `Preferences.sublime-settings` file additional mappings.  See [`mdpopups.sublime_user_lang_map`](./settings.md#mdpopupssublime_user_lang_map) for more info.
+As previously mentioned, MdPopups uses the internal syntax highlighter to highlight your code.  The benefit here is that
+you get code highlighting in your popup that matches your current theme.  The highlighting ability is dependent upon
+what syntax packages you have installed in Sublime.  It also depends on whether that syntax is enabled and mapped to a
+language keyword.  Pull requests are welcome to expand and keep the [language mapping][language-map] updated.  You can
+also define in your `Preferences.sublime-settings` file additional mappings.  See
+[`mdpopups.sublime_user_lang_map`](./settings.md#mdpopupssublime_user_lang_map) for more info.
 
-Most users prefer using syntax highlighting that matches their current color scheme. If you are a developer, it is recommended to issue a pull request to add missing languages you need to the mapping. Optionally you can also describe how users can map what they need locally.
+Most users prefer using syntax highlighting that matches their current color scheme. If you are a developer, it is
+recommended to issue a pull request to add missing languages you need to the mapping. Optionally you can also describe
+how users can map what they need locally.
 
 ### Pygments
 
-In order to use Pygments, you have to disable `mdpopups.use_sublime_highlighter`. Pygments has a great variety of highlighters out of the box.  It also comes with a number of built-in color schemes that can be used. When enabling Pygments, you must specify the color scheme to use in your user CSS using the [CSS template filter](#css-templates).
+In order to use Pygments, you have to disable `mdpopups.use_sublime_highlighter`. Pygments has a great variety of
+highlighters out of the box.  It also comes with a number of built-in color schemes that can be used. When enabling
+Pygments, you must specify the color scheme to use in your user CSS using the [CSS template filter](#css-templates).
 
 ```css+jinja
 /* Syntax Highlighting */
@@ -25,9 +36,13 @@ In order to use Pygments, you have to disable `mdpopups.use_sublime_highlighter`
 {%- endif %}
 ```
 
-You can also paste your own custom Pygments CSS directly into your User CSS, but you will have to format it to work properly.
+You can also paste your own custom Pygments CSS directly into your User CSS, but you will have to format it to work
+properly.
 
-Pygments defines special classes for each span that needs to be highlighted in a coding block. Pygments CSS classes are not only given syntax classes that are applied to each span, but usually an overall class is assigned to a `#!html <div>` wrapper as well.  For instance, a class for whitespace may look like this (where `#!css .highlight` is the div wrapper's class and `#!css .w` i the span's class):
+Pygments defines special classes for each span that needs to be highlighted in a coding block. Pygments CSS classes are
+not only given syntax classes that are applied to each span, but usually an overall class is assigned to a
+`#!html <div>` wrapper as well.  For instance, a class for whitespace may look like this (where `#!css .highlight` is
+the div wrapper's class and `#!css .w` i the span's class):
 
 ```css
 .highlight .w { color: #cccccc } /* Text.Whitespace */
@@ -111,7 +126,10 @@ If doing your own, the Pygments CSS should define a rule to highlight general ba
 
 ## CSS Styling
 
-One reason MdPopups was created was to give consistent popups across plugins. Originally MdPopups forced its style so that plugins couldn't override the it. Later it was realized that plugins may have reasons to override certain things, and in recent versions, this constraint was relaxed. Despite changes since its inception, one thing has stayed the same: the user has the last say in how popups work. This is achieved by controlling which CSS gets loaded when.
+One reason MdPopups was created was to give consistent popups across plugins. Originally MdPopups forced its style so
+that plugins couldn't override the it. Later it was realized that plugins may have reasons to override certain things,
+and in recent versions, this constraint was relaxed. Despite changes since its inception, one thing has stayed the same:
+the user has the last say in how popups work. This is achieved by controlling which CSS gets loaded when.
 
 ```flow
 st=>operation: Sublime CSS/Color Scheme CSS
@@ -122,13 +140,22 @@ us=>operation: User CSS
 st->md->pg->us
 ```
 
-Sublime first provides its CSS which includes some basic styling and CSS from color schemes. MdPopups provides its own default CSS that styles the common HTML tags and provides minimal colors. Plugins come next and extend the CSS with plugin specific CSS. The user's CSS is loaded last and can override anything.
+Sublime first provides its CSS which includes some basic styling and CSS from color schemes. MdPopups provides its own
+default CSS that styles the common HTML tags and provides minimal colors. Plugins come next and extend the CSS with
+plugin specific CSS. The user's CSS is loaded last and can override anything.
 
-All CSS is passed through the Jinja2 template engine where special filters can provide things like appropriate CSS that matches your color scheme for a specific scope, load additional CSS from another source, have condition logic for specific Sublime and/or MdPopups versions, or even provide CSS for specific color schemes.
+All CSS is passed through the Jinja2 template engine where special filters can provide things like appropriate CSS that
+matches your color scheme for a specific scope, load additional CSS from another source, have condition logic for
+specific Sublime and/or MdPopups versions, or even provide CSS for specific color schemes.
 
-Templates are used so that a user can easily tap into all the colors, color filters, and other useful logic to control their popups and phantoms in one place without having to hard code a specific CSS for a specific color scheme.
+Templates are used so that a user can easily tap into all the colors, color filters, and other useful logic to control
+their popups and phantoms in one place without having to hard code a specific CSS for a specific color scheme.
 
-In general, it is encouraged to use Sublime CSS variables such as `--redish`, `--bluish`, etc. to get appropriate colors for a given theme. Sublime calculates these colors from the color scheme directly. If it calculates a color that is not quite right, you can always request that the color scheme in question redefines that variable with an appropriate color.  Or you, as the user, can define one in your user CSS. You can read more about `minihtml` and it's features in the [`minihtml` documentation][minihtml].
+In general, it is encouraged to use Sublime CSS variables such as `--redish`, `--bluish`, etc. to get appropriate colors
+for a given theme. Sublime calculates these colors from the color scheme directly. If it calculates a color that is not
+quite right, you can always request that the color scheme in question redefines that variable with an appropriate color.
+Or you, as the user, can define one in your user CSS. You can read more about `minihtml` and it's features in the
+[`minihtml` documentation][minihtml].
 
 MdPopups also provides its own CSS variables that can be overridden by a user:
 
@@ -164,17 +191,23 @@ Variable                            | Description
 
 ## CSS Templates
 
-All variables and filters provided by default *only* apply to the CSS, not the markdown or HTML content. The default provided variables are namespaced under `var`.
+All variables and filters provided by default *only* apply to the CSS, not the markdown or HTML content. The default
+provided variables are namespaced under `var`.
 
-The Markdown and HTML content only receives the variables that are given via `template_vars` parameters and any options via the `template_env_options`; user defined variables will get passed to the CSS, but not the options. User defined variables will be namespaced under `plugin`.
+The Markdown and HTML content only receives the variables that are given via `template_vars` parameters and any options
+via the `template_env_options`; user defined variables will get passed to the CSS, but not the options. User defined
+variables will be namespaced under `plugin`.
 
 ### CSS Filter
 
-With the template environment, colors and style from the current Sublime color scheme can be accessed and manipulated.  Access to the Sublime color scheme styles CSS is done via the `css` filter.
+With the template environment, colors and style from the current Sublime color scheme can be accessed and manipulated.
+Access to the Sublime color scheme styles CSS is done via the `css` filter.
 
 `css`
 : 
-    Retrieves the style for a specific Sublime scope from a Sublime color scheme.  By specifying either `foreground`, `background`, or any scope (complexity doesn't really matter) and feeding it into the `css` filter, all the related styling of the specified scope will be inserted as CSS into the CSS document.
+    Retrieves the style for a specific Sublime scope from a Sublime color scheme.  By specifying either `foreground`,
+    `background`, or any scope (complexity doesn't really matter) and feeding it into the `css` filter, all the related
+    styling of the specified scope will be inserted as CSS into the CSS document.
 
     **Example**:
 
@@ -190,9 +223,11 @@ With the template environment, colors and style from the current Sublime color s
     h1, h2, h3, h4, h5, h6 { color: #888888; font-style: italic; }
     ```
 
-    Notice that the format of insertion is `key: value; `.  You do not need a semicolon after as the CSS lines are all formatted properly with semicolons.  If you add one, you may get multiple semicolons which *may* break the CSS.
+    Notice that the format of insertion is `key: value; `.  You do not need a semicolon after as the CSS lines are all
+    formatted properly with semicolons.  If you add one, you may get multiple semicolons which *may* break the CSS.
 
-    If you need to get at a specific CSS attribute, you can specify its name in the `css` filter (available attributes are `color`, `background-color`, `font-style`, and `font-weight`).
+    If you need to get at a specific CSS attribute, you can specify its name in the `css` filter (available attributes
+    are `color`, `background-color`, `font-style`, and `font-weight`).
 
     This:
 
@@ -206,7 +241,9 @@ With the template environment, colors and style from the current Sublime color s
     h1, h2, h3, h4, h5, h6 { color: #888888; }
     ```
 
-    In general, a foreground color is always returned, but by default, a background color is only returned if one is explicitly defined. To always get a background (which most likely will default to the overall scheme background), you can set the additional `explicit_background` parameter to `#!py False`.
+    In general, a foreground color is always returned, but by default, a background color is only returned if one is
+    explicitly defined. To always get a background (which most likely will default to the overall scheme background),
+    you can set the additional `explicit_background` parameter to `#!py False`.
 
     ```css+jinja
     /* If `keyword.operator` is not explicitly used, fallback to `.keyword` */
@@ -215,9 +252,15 @@ With the template environment, colors and style from the current Sublime color s
 
 ### Color Filters
 
-MdPopups also provides a number of color filters within the template environment that can manipulate the CSS colors returned from the `css` filter (or equivalent formatted CSS). These filters will strip out the color and modify it, and return the appropriate CSS.  To manipulate a color value directly, you can use Sublime's built in color blending.  In most cases, it is advised to use Sublime's color blending functionality, but these are available to aid those who wish to access and manipulate CSS of scopes directly.  See Sublime's [`minihtml` documentation][minihtml] for more info.
+MdPopups also provides a number of color filters within the template environment that can manipulate the CSS colors
+returned from the `css` filter (or equivalent formatted CSS). These filters will strip out the color and modify it, and
+return the appropriate CSS.  To manipulate a color value directly, you can use Sublime's built in color blending.  In
+most cases, it is advised to use Sublime's color blending functionality, but these are available to aid those who wish
+to access and manipulate CSS of scopes directly.  See Sublime's [`minihtml` documentation][minihtml] for more info.
 
-Even though Sublime generally provides contrast to popups, lets pretend you had a popup that was the same color as the view window and it was difficult to see where the popup starts and ends.  You can take the color schemes background and apply a brightness filter to it allowing you now see the popup clearly.
+Even though Sublime generally provides contrast to popups, lets pretend you had a popup that was the same color as the
+view window and it was difficult to see where the popup starts and ends.  You can take the color schemes background and
+apply a brightness filter to it allowing you now see the popup clearly.
 
 Here we can make the background of the popup darker:
 
@@ -225,14 +268,20 @@ Here we can make the background of the popup darker:
 .mdpopups div.myplugin { {{'.background'|css('background-color')|brightness(0.9)}} }
 ```
 
-Color filters take a single color attribute of the form `key: value;`.  So when feeding the color template filters your CSS via the `css` filter, you should specify the color attribute (`background-color` or `color`) that you wish to apply the filter to; it may be difficult to tell how many attributes `css` could return without explicitly specifying attribute.  Color filters only take either `color` or `background-color` attributes.
+Color filters take a single color attribute of the form `key: value;`.  So when feeding the color template filters your
+CSS via the `css` filter, you should specify the color attribute (`background-color` or `color`) that you wish to apply
+the filter to; it may be difficult to tell how many attributes `css` could return without explicitly specifying
+attribute.  Color filters only take either `color` or `background-color` attributes.
 
-Filters can be chained if more intensity is needed (as some filters may clamp the value in one call), or if you want to apply multiple filters.  These are all the available filters:
+Filters can be chained if more intensity is needed (as some filters may clamp the value in one call), or if you want to
+apply multiple filters.  These are all the available filters:
 
 `foreground` and `background`
 : 
 
-    If desired, you can convert a foreground color to a background color or vice versa.  To convert to a foreground color, you can use the `foreground` filter.  To convert to a background color, you can use the `background` filter. Remember, this is augmenting the CSS returned by the `css` filter, you can't just give it a color. 
+    If desired, you can convert a foreground color to a background color or vice versa.  To convert to a foreground
+    color, you can use the `foreground` filter.  To convert to a background color, you can use the `background` filter.
+    Remember, this is augmenting the CSS returned by the `css` filter, you can't just give it a color. 
 
 
     To convert a background to a foreground.
@@ -251,7 +300,8 @@ Filters can be chained if more intensity is needed (as some filters may clamp th
 
 `brightness`
 : 
-    Shifts brightness either dark or lighter. Brightness is relative to 1 where 1 means no change.  Accepted values are floats that are greater than 0.  Ranges are clamped between 0 and 2.
+    Shifts brightness either dark or lighter. Brightness is relative to `1` where `1` means no change.  Accepted values
+    are floats that are greater than `0`.  Ranges are clamped between `0` and `2`.
 
     **Example - Darken**:
     ```css+jinja
@@ -265,7 +315,8 @@ Filters can be chained if more intensity is needed (as some filters may clamp th
 
 `contrast`
 : 
-    Increases/decreases the contrast.  Contrast is relative to 1 where 1 means no change.  Accepted values are floats that are greater than 0.  Ranges are clamped between 0 and 2.
+    Increases/decreases the contrast.  Contrast is relative to `1` where `1` means no change.  Accepted values are
+    floats that are greater than `0`.  Ranges are clamped between `0` and `2`.
 
     **Example - Decrease contrast**:
     ```css+jinja
@@ -279,7 +330,8 @@ Filters can be chained if more intensity is needed (as some filters may clamp th
 
 `saturation`
 : 
-    Shifts the saturation either to right (saturate) or the left (desaturate).  Saturation is relative to 1 where 1 means no change.  Accepted values are floats that are greater than 0.  Ranges are clamped between 0 and 2.
+    Shifts the saturation either to right (saturate) or the left (desaturate).  Saturation is relative to `1` where `1`
+    means no change.  Accepted values are floats that are greater than `0`.  Ranges are clamped between `0` and `2`.
 
     **Example - Desaturate**:
     ```css+jinja
@@ -320,7 +372,9 @@ Filters can be chained if more intensity is needed (as some filters may clamp th
 
 `colorize`
 : 
-    Filters all colors to a shade of the specified hue.  Think grayscale, but instead of gray, you define a non-gray hue.  The values are angular dimensions starting at the red primary at 0°, passing through the green primary at 120° and the blue primary at 240°, and then wrapping back to red at 360°.
+    Filters all colors to a shade of the specified hue.  Think grayscale, but instead of gray, you define a non-gray
+    hue.  The values are angular dimensions starting at the red primary at 0°, passing through the green primary at 120°
+    and the blue primary at 240°, and then wrapping back to red at 360°.
 
     **Example**:
     ```css+jinja
@@ -329,7 +383,9 @@ Filters can be chained if more intensity is needed (as some filters may clamp th
 
 `hue`
 : 
-    Shifts the current hue either to the left or right.  The values are angular dimensions starting at the red primary at 0°, passing through the green primary at 120° and the blue primary at 240°, and then wrapping back to red at 360°.  Values can either be negative to shift left or positive to shift the hue to the right.
+    Shifts the current hue either to the left or right.  The values are angular dimensions starting at the red primary
+    at 0°, passing through the green primary at 120° and the blue primary at 240°, and then wrapping back to red at
+    360°.  Values can either be negative to shift left or positive to shift the hue to the right.
 
     **Example - Left Shift**:
     ```css+jinja
@@ -343,7 +399,8 @@ Filters can be chained if more intensity is needed (as some filters may clamp th
 
 `fade`
 : 
-    Fades a color. Essentially it is like apply transparency to the color allowing the color schemes base background color to show through.
+    Fades a color. Essentially it is like apply transparency to the color allowing the color schemes base background
+    color to show through.
 
     **Example - Fade 50%**:
     ```css+jinja
@@ -352,11 +409,13 @@ Filters can be chained if more intensity is needed (as some filters may clamp th
 
 ### Include CSS Filter
 
-The template environment allows for retrieving CSS resources from Sublime Packages or built-in Pygments CSS from the Pygments library.
+The template environment allows for retrieving CSS resources from Sublime Packages or built-in Pygments CSS from the
+Pygments library.
 
 `getcss`
 : 
-    Retrieve a CSS file from Sublime's `Packages` folder.  CSS retrieved in this manner can include template variables and filters.
+    Retrieve a CSS file from Sublime's `Packages` folder.  CSS retrieved in this manner can include template variables
+    and filters.
 
     **Example**:
     ```css+jinja
@@ -374,11 +433,13 @@ The template environment allows for retrieving CSS resources from Sublime Packag
 
 ## Template Variables
 
-The template environment provides a couple of variables that can be used to conditionally alter the CSS output.  Variables are found under `var`.
+The template environment provides a couple of variables that can be used to conditionally alter the CSS output.
+Variables are found under `var`.
 
 `var.sublime_version`
 : 
-    `sublime_version` contains the current Sublime Text version.  This allows you conditionally handle CSS features that are specific to a Sublime Text version.
+    `sublime_version` contains the current Sublime Text version.  This allows you conditionally handle CSS features that
+    are specific to a Sublime Text version.
 
     **Example**
     ```css+jinja
@@ -404,11 +465,13 @@ The template environment provides a couple of variables that can be used to cond
 
 `var.default_style`
 : 
-    Flag specifying whether default styling is being used.  See [`mdpopups.default_style`](./settings.md#mdpopupsdefault_style) for how to control this flag.  And see [`default.css`][default-css] for an example of how it is used.
+    Flag specifying whether default styling is being used.  See [`mdpopups.default_style`](./settings.md#mdpopupsdefault_style)
+    for how to control this flag.  And see [`default.css`][default-css] for an example of how it is used.
 
 `var.is_dark` and `var.is_light`
 : 
-    `is_dark` checks if the color scheme is a dark color scheme.  Alternatively, `is_light` checks if the color scheme is a light color scheme.
+    `is_dark` checks if the color scheme is a dark color scheme.  Alternatively, `is_light` checks if the color scheme
+    is a light color scheme.
 
     **Example**:
     ```css+jinja
@@ -421,7 +484,8 @@ The template environment provides a couple of variables that can be used to cond
 
 `var.is_popup`, `var.is_phantom`, and `var.is_sheet`
 : 
-    `is_phantom` checks if the current CSS is for a phantom instead of a popup.  Alternatively, `is_popup` and `is_sheet` checks if the current use of the CSS is for a popup or HTML sheet respectively.
+    `is_phantom` checks if the current CSS is for a phantom instead of a popup.  Alternatively, `is_popup` and
+    `is_sheet` checks if the current use of the CSS is for a popup or HTML sheet respectively.
 
     **Example**:
     ```css+jinja

--- a/st3/mdpopups/__init__.py
+++ b/st3/mdpopups/__init__.py
@@ -305,8 +305,7 @@ def _remove_entities(text):
 
 def _create_html(
     view, content, md=True, css=None, debug=False, css_type=POPUP,
-    wrapper_class=None, template_vars=None, template_env_options=None, nl2br=True,
-    allow_code_wrap=False
+    wrapper_class=None, template_vars=None, template_env_options=None
 ):
     """Create HTML from content."""
 
@@ -324,8 +323,7 @@ def _create_html(
     if md:
         content = md2html(
             view, content, template_vars=template_vars,
-            template_env_options=template_env_options, nl2br=nl2br,
-            allow_code_wrap=allow_code_wrap
+            template_env_options=template_env_options
         )
     else:
         # Strip out frontmatter if found as we don't currently
@@ -371,8 +369,7 @@ def version():
 
 
 def md2html(
-    view, markup, template_vars=None, template_env_options=None,
-    nl2br=True, allow_code_wrap=False
+    view, markup, template_vars=None, template_env_options=None, **kwargs
 ):
     """Convert Markdown to HTML."""
 
@@ -413,13 +410,10 @@ def md2html(
                 "markdown.extensions.def_list",
                 "pymdownx.betterem",
                 "pymdownx.magiclink",
-                "pymdownx.extrarawhtml"
+                "pymdownx.extrarawhtml",
+                "markdown.extensions.nl2br"
             ]
         )
-
-        # Use legacy method to determine if `nl2br` should be used
-        if nl2br:
-            extensions.append('markdown.extensions.nl2br')
     else:
         for ext in md_exts:
             if isinstance(ext, (dict, OrderedDict)):
@@ -437,7 +431,7 @@ def md2html(
         extensions=extensions,
         extension_configs=configs,
         sublime_hl=sublime_hl,
-        allow_code_wrap=fm.get('allow_code_wrap', allow_code_wrap)
+        allow_code_wrap=fm.get('allow_code_wrap', False)
     ).convert(_markup_template(markup, template_vars, template_env_options)).replace('&quot;', '"')
 
 
@@ -582,8 +576,7 @@ def hide_popup(view):
 
 def update_popup(
     view, content, md=True, css=None, wrapper_class=None,
-    template_vars=None, template_env_options=None, nl2br=True,
-    allow_code_wrap=False
+    template_vars=None, template_env_options=None, **kwargs
 ):
     """Update the popup."""
 
@@ -595,8 +588,7 @@ def update_popup(
     try:
         html = _create_html(
             view, content, md, css, css_type=POPUP, wrapper_class=wrapper_class,
-            template_vars=template_vars, template_env_options=template_env_options, nl2br=nl2br,
-            allow_code_wrap=allow_code_wrap
+            template_vars=template_vars, template_env_options=template_env_options
         )
     except Exception:
         _log(traceback.format_exc())
@@ -609,8 +601,7 @@ def show_popup(
     view, content, md=True, css=None,
     flags=0, location=-1, max_width=320, max_height=240,
     on_navigate=None, on_hide=None, wrapper_class=None,
-    template_vars=None, template_env_options=None, nl2br=True,
-    allow_code_wrap=False
+    template_vars=None, template_env_options=None, **kwargs
 ):
     """Parse the color scheme if needed and show the styled pop-up."""
 
@@ -625,8 +616,7 @@ def show_popup(
     try:
         html = _create_html(
             view, content, md, css, css_type=POPUP, wrapper_class=wrapper_class,
-            template_vars=template_vars, template_env_options=template_env_options,
-            nl2br=nl2br, allow_code_wrap=allow_code_wrap
+            template_vars=template_vars, template_env_options=template_env_options
         )
     except Exception:
         _log(traceback.format_exc())
@@ -647,8 +637,7 @@ def is_popup_visible(view):
 def add_phantom(
     view, key, region, content, layout, md=True,
     css=None, on_navigate=None, wrapper_class=None,
-    template_vars=None, template_env_options=None, nl2br=True,
-    allow_code_wrap=False
+    template_vars=None, template_env_options=None, **kwargs
 ):
     """Add a phantom and return phantom id."""
 
@@ -660,8 +649,7 @@ def add_phantom(
     try:
         html = _create_html(
             view, content, md, css, css_type=PHANTOM, wrapper_class=wrapper_class,
-            template_vars=template_vars, template_env_options=template_env_options,
-            nl2br=nl2br, allow_code_wrap=allow_code_wrap
+            template_vars=template_vars, template_env_options=template_env_options
         )
     except Exception:
         _log(traceback.format_exc())
@@ -697,8 +685,7 @@ def query_phantoms(view, pids):
 if HTML_SHEET_SUPPORT:
     def new_html_sheet(
         window, name, contents, md=True, css=None, flags=0, group=-1,
-        wrapper_class=None, template_vars=None, template_env_options=None, nl2br=False,
-        allow_code_wrap=False
+        wrapper_class=None, template_vars=None, template_env_options=None, **kwargs
     ):
         """Create new HTML sheet."""
 
@@ -706,8 +693,7 @@ if HTML_SHEET_SUPPORT:
         try:
             html = _create_html(
                 view, contents, md, css, css_type=SHEET, wrapper_class=wrapper_class,
-                template_vars=template_vars, template_env_options=template_env_options, nl2br=nl2br,
-                allow_code_wrap=allow_code_wrap
+                template_vars=template_vars, template_env_options=template_env_options
             )
         except Exception:
             _log(traceback.format_exc())
@@ -717,7 +703,7 @@ if HTML_SHEET_SUPPORT:
 
     def update_html_sheet(
         sheet, contents, md=True, css=None, wrapper_class=None,
-        template_vars=None, template_env_options=None, nl2br=False, allow_code_wrap=False
+        template_vars=None, template_env_options=None, **kwargs
     ):
         """Update an HTML sheet."""
 
@@ -727,8 +713,7 @@ if HTML_SHEET_SUPPORT:
         try:
             html = _create_html(
                 view, contents, md, css, css_type=SHEET, wrapper_class=wrapper_class,
-                template_vars=template_vars, template_env_options=template_env_options, nl2br=nl2br,
-                allow_code_wrap=allow_code_wrap
+                template_vars=template_vars, template_env_options=template_env_options
             )
         except Exception:
             _log(traceback.format_exc())
@@ -743,8 +728,7 @@ class Phantom(sublime.Phantom):
     def __init__(
         self, region, content, layout, md=True,
         css=None, on_navigate=None, wrapper_class=None,
-        template_vars=None, template_env_options=None, nl2br=True,
-        allow_code_wrap=False
+        template_vars=None, template_env_options=None, **kwargs
     ):
         """Initialize."""
 
@@ -754,8 +738,6 @@ class Phantom(sublime.Phantom):
         self.wrapper_class = wrapper_class
         self.template_vars = template_vars
         self.template_env_options = template_env_options
-        self.nl2br = nl2br
-        self.allow_code_wrap = allow_code_wrap
 
     def __eq__(self, rhs):
         """Check if phantoms are equal."""
@@ -764,10 +746,9 @@ class Phantom(sublime.Phantom):
         return (
             self.region == rhs.region and self.content == rhs.content and
             self.layout == rhs.layout and self.on_navigate == rhs.on_navigate and
-            self.md == rhs.md and self.css == rhs.css and self.nl2br == rhs.nl2br and
+            self.md == rhs.md and self.css == rhs.css and
             self.wrapper_class == rhs.wrapper_class and self.template_vars == rhs.template_vars and
-            self.template_env_options == rhs.template_env_options and
-            self.allow_code_wrap == rhs.allow_code_wrap
+            self.template_env_options == rhs.template_env_options
         )
 
 
@@ -799,8 +780,7 @@ class PhantomSet(sublime.PhantomSet):
                 p = Phantom(
                     p.region, p.content, p.layout,
                     md=False, css=None, on_navigate=p.on_navigate, wrapper_class=None,
-                    template_vars=None, template_env_options=None, nl2br=False,
-                    allow_code_wrap=False
+                    template_vars=None, template_env_options=None
                 )
                 new_phantoms[count] = p
             try:
@@ -819,9 +799,7 @@ class PhantomSet(sublime.PhantomSet):
                     p.on_navigate,
                     p.wrapper_class,
                     p.template_vars,
-                    p.template_env_options,
-                    p.nl2br,
-                    p.allow_code_wrap
+                    p.template_env_options
                 )
             count += 1
 

--- a/st3/mdpopups/version.py
+++ b/st3/mdpopups/version.py
@@ -1,6 +1,6 @@
 """Version."""
 
-_version_info = (3, 7, 5)
+_version_info = (4, 0, 0)
 __version__ = '.'.join([str(x) for x in _version_info])
 
 


### PR DESCRIPTION
Users should specify both these options via frontmatter.
`allow_code_wrap` is still a parameter in the `syntax_highlight`
function.