### PR TITLE
Fix typos and deprecation

### DIFF
--- a/st3/mdpopups/st_code_highlight.py
+++ b/st3/mdpopups/st_code_highlight.py
@@ -243,7 +243,7 @@ class SublimeHighlight(object):
                             sublime.load_binary_resource(syntax_file)
                         except Exception:
                             continue
-                        self.view.set_syntax_file(syntax_file)
+                        self.view.assign_syntax(syntax_file)
                         loaded = True
                         break
                     if loaded:
@@ -259,7 +259,7 @@ class SublimeHighlight(object):
                     sublime.load_binary_resource(syntax_file)
                 except Exception:
                     continue
-                self.view.set_syntax_file(syntax_file)
+                self.view.assign_syntax(syntax_file)
 
     def syntax_highlight(self, src, lang, hl_lines=[], inline=False, no_wrap=False, code_wrap=False, plugin_map=None):
         """Syntax Highlight."""

--- a/st3/mdpopups/st_code_highlight.py
+++ b/st3/mdpopups/st_code_highlight.py
@@ -238,12 +238,12 @@ class SublimeHighlight(object):
             if lang in (tuple(user_v[0]) + plugin_v[0] + v[0]):
                 for l in (tuple(user_v[1]) + plugin_v[1] + v[1]):
                     for ext in ST_LANGUAGES:
-                        sytnax_file = 'Packages/{}{}'.format(l, ext)
+                        syntax_file = 'Packages/{}{}'.format(l, ext)
                         try:
-                            sublime.load_binary_resource(sytnax_file)
+                            sublime.load_binary_resource(syntax_file)
                         except Exception:
                             continue
-                        self.view.set_syntax_file(sytnax_file)
+                        self.view.set_syntax_file(syntax_file)
                         loaded = True
                         break
                     if loaded:
@@ -254,12 +254,12 @@ class SublimeHighlight(object):
             # Default to plain text
             for ext in ST_LANGUAGES:
                 # Just in case text one day switches to 'sublime-syntax'
-                sytnax_file = 'Packages/Text/Plain text{}'.format(ext)
+                syntax_file = 'Packages/Text/Plain text{}'.format(ext)
                 try:
-                    sublime.load_binary_resource(sytnax_file)
+                    sublime.load_binary_resource(syntax_file)
                 except Exception:
                     continue
-                self.view.set_syntax_file(sytnax_file)
+                self.view.set_syntax_file(syntax_file)
 
     def syntax_highlight(self, src, lang, hl_lines=[], inline=False, no_wrap=False, code_wrap=False, plugin_map=None):
         """Syntax Highlight."""


### PR DESCRIPTION
`view.set_syntax_file` had been deprecated even in the very old [min requirement (ST 3080)](https://github.com/facelessuser/sublime-channel/blob/974589d47a652f4ff31afed35a79be2f4ee3fb02/repositories.json#L75-L88) for mdpopups.

![image](https://user-images.githubusercontent.com/6594915/182065679-b34c7442-cee2-4848-b912-06bfc8724239.png)
