### PR TITLE
Use source.LANG/text.LANG as language map fallbacks for ST 4

### DIFF
--- a/docs/src/dictionary/en-custom.txt
+++ b/docs/src/dictionary/en-custom.txt
@@ -57,6 +57,7 @@ docstring
 docstrings
 ebeweber
 facelessuser
+fallbacks
 flashios
 formatter
 frontmatter

--- a/docs/src/markdown/settings.md
+++ b/docs/src/markdown/settings.md
@@ -87,6 +87,13 @@ extending, the user mappings will be cycled through first.
 }
 ```
 
+If you are using ST 4, you can also use `scope:BASE_SCOPE` to select a syntax.
+```js
+"mdpopups.sublime_user_lang_map": {
+    "javascript": [["javascript", "js"], ["scope:source.js"]]
+}
+```
+
 For a list of all currently supported syntax mappings, see the official [mapping file][language-map].
 
 !!! tip "Tip"

--- a/st3/mdpopups/st_code_highlight.py
+++ b/st3/mdpopups/st_code_highlight.py
@@ -250,6 +250,15 @@ class SublimeHighlight(object):
                         break
             if loaded:
                 break
+        # For ST 4, use "source.LANG" and "text.LANG" as fallbacks if possible
+        if not loaded and hasattr(sublime, 'find_syntax_by_scope'):
+            for scope in ('source.' + lang, 'text.' + lang):
+                syntaxes = sublime.find_syntax_by_scope(scope)
+                if not syntaxes:
+                    continue
+                self.view.assign_syntax(syntaxes[0])
+                loaded = True
+                break
         if not loaded:
             # Default to plain text
             for ext in ST_LANGUAGES:

--- a/st3/mdpopups/st_code_highlight.py
+++ b/st3/mdpopups/st_code_highlight.py
@@ -237,6 +237,13 @@ class SublimeHighlight(object):
             user_v = user_map.get(key, (tuple(), tuple()))
             if lang in (tuple(user_v[0]) + plugin_v[0] + v[0]):
                 for l in (tuple(user_v[1]) + plugin_v[1] + v[1]):
+                    if l.startswith('scope:'):
+                        scope = l[6:]  # remove "scope:" prefix
+                        if self.set_syntax_by_scope(scope):
+                            loaded = True
+                            break
+                        continue
+
                     for ext in ST_LANGUAGES:
                         sytnax_file = 'Packages/{}{}'.format(l, ext)
                         try:
@@ -250,15 +257,12 @@ class SublimeHighlight(object):
                         break
             if loaded:
                 break
-        # For ST 4, use "source.LANG" and "text.LANG" as fallbacks if possible
-        if not loaded and hasattr(sublime, 'find_syntax_by_scope'):
+        if not loaded:
+            # Use "source.LANG" and "text.LANG" as fallbacks if possible
             for scope in ('source.' + lang, 'text.' + lang):
-                syntaxes = sublime.find_syntax_by_scope(scope)
-                if not syntaxes:
-                    continue
-                self.view.assign_syntax(syntaxes[0])
-                loaded = True
-                break
+                if self.set_syntax_by_scope(scope):
+                    loaded = True
+                    break
         if not loaded:
             # Default to plain text
             for ext in ST_LANGUAGES:
@@ -285,3 +289,12 @@ class SublimeHighlight(object):
         self.html = []
         self.write_body()
         return ''.join(self.html)
+
+    def set_syntax_by_scope(self, scope):
+        """Set syntax by the `scope`. Only works in ST 4."""
+        if hasattr(sublime, 'find_syntax_by_scope'):
+            syntaxes = sublime.find_syntax_by_scope(scope)
+            if syntaxes:
+                self.view.assign_syntax(syntaxes[0])
+                return True
+        return False


### PR DESCRIPTION
Probably resolves https://github.com/facelessuser/sublime-markdown-popups/issues/102 @rchl @rwols 

---

Answer to concerns in #102:

- This feature is activated if and only if `sublime.find_syntax_by_scope`, which is introduced in the very first ST 4 dev build, is available.
- Since this is a fallback, users can still set the correct dialect in the language map if that's what they want.
- Language map is still preferred and there is no need to maintain two version of `mdpopups` or language map.
