### PR TITLE
Exclude unused files from download archives

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,13 @@
-docs/ export-ignore
+# git related
 .github/ export-ignore
+.gitattributes export-ignore
+.gitignore export-ignore
+
+# docs
+docs/ export-ignore
+mkdocs.yml export-ignore
+
+# tests
+tests/ export-ignore
+.pyspelling.yml export-ignore
+tox.ini export-ignore

--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,7 @@ target/
 site/*
 *.patch
 dictionary.bin
+
+# Sublime Text
+*.sublime-project
+*.sublime-workspace


### PR DESCRIPTION
This PR proposes to...

1. mark all files and folders `export-ignore`, which are not required to install the dependency.
2. ignore ST project and workspace files to make sure to keep them local, if exist.

A minor improvement to make sure to download only what's needed.

The idea is to create mdpopups.sublime-package file with everything except `st3` folder to keep package style resources (e.g.: Preferences.sublime-settings) available.
