### PR TITLE
Add pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,13 @@
+[build-system]
+requires = ["setuptools", "setuptools-scm"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools]
+package-dir = { "" = "st3" }
+packages    = ["mdpopups"]
+
+[project]
+name = "mdpopups"
+requires-python = "== 3.8"
+dependencies = [] # We vendor dependencies
+version = "3.7.0"


### PR DESCRIPTION
### Background / Problem Statement

I am exploring replacing some Package Control specific infrastructure with Python-standard tooling.

At present, that means I've replaced Package Control for my uses with a Ruby script that installs packages with `git clone` and dependencies with `pip install`. 

https://gist.github.com/MatthiasPortzel/4978c1188537d9bf280ad41a30a86b7a

The specific invocation that I'm using to install dependencies looks like:
```bash
uv pip install --python 3.8 --python-version 3.8 --upgrade --target $SUBLIME_DIR/Lib/python38 #{dependency}
```

This works for most packages and for dependencies on PiPy. However, this library, which is a dependency of packages like LSP, is not available on PiPy and is not understood by Pip to be an installable python project because of the lack of pyproject.toml.

### Solution

This PR adds a pyproject.toml file to the project. This means that, (in addition to being installed with Package Control) the package can be installed using a command like the above with `git+URL`, and indeed this works today with `git+https://github.com/MatthiasPortzel/sublime-markdown-popups`.

I'm not opinionated about the particular details of the pyproject.toml. If you're not familar with the format, it basically tells pip to use setuptools to build the project, and then tells setuptools that the project is one module called `mdpopups` in the `st3` directory. "building the project" in this case is just copying those files and the dependencies sub-modules into /Lib but there are many more ways to use this, including platform-specific builds.

### Other advantages

My hope, long term, is that Package Control or future Sublime Text package management solutions will support these ecosystem-standards like pyproject.toml, pip, and PiPy.

https://pip.pypa.io/en/stable/reference/build-system/pyproject-toml/

This will bring other advantages, like the ability to specify dependencies in the pyproject.toml file. For example, in adding a pyproject.toml to lsp_utils, I removed the vendored dependency and replaced it with an entry in the pyproject.toml. When installing lsp_utils, pip is able to recursively find the dependencies and install the package. Of course, I can't PR this approach without breaking things for Package Control users. (Which is why I didn't take that approach here.)

https://github.com/MatthiasPortzel/lsp_utils/commit/cc82f3028b36a47677b0eecb12e2f6bb979d38c3

### Conclusion

In addition to this specific PR, I'm interested in hearing thoughts on if this is a direction worth exploring across more repositories as well.