### PR TITLE
Fix py313 compatibility (ST 4201)

### DIFF
--- a/st3/mdpopups/__init__.py
+++ b/st3/mdpopups/__init__.py
@@ -17,6 +17,7 @@ import time
 import codecs
 import html
 import html.parser
+import sys
 import urllib
 import functools
 import base64
@@ -108,6 +109,12 @@ def _can_show(view, location=-1):
         can_show = False
 
     return can_show
+
+
+if sys.version_info < (3, 4):
+    _unescape_html = html.parser.HTMLParser().unescape
+else:
+    _unescape_html = html.unescape
 
 
 ##############################
@@ -316,11 +323,9 @@ def _get_theme(view, css=None, css_type=POPUP, template_vars=None):
 def _remove_entities(text):
     """Remove unsupported HTML entities."""
 
-    p = html.parser.HTMLParser()
-
     def repl(m):
         """Replace entities except &, <, >, and `nbsp`."""
-        return p.unescape(m.group(1))
+        return _unescape_html(m.group(1))
 
     return RE_BAD_ENTITIES.sub(repl, text)
 
@@ -894,7 +899,7 @@ def _image_parser(text):
         m2 = RE_TAG_LINK_ATTR.search(m.group('attr'))
         if m2:
             src = m2.group('path')[1:-1]
-            src = html.parser.HTMLParser().unescape(src)
+            src = _unescape_html(src)
             if urllib.parse.urlparse(src).scheme in ("http", "https"):
                 s = start + m2.start('path') + 1
                 e = start + m2.end('path') - 1

--- a/st3/mdpopups/jinja2/tests.py
+++ b/st3/mdpopups/jinja2/tests.py
@@ -10,7 +10,7 @@
 """
 import operator
 import re
-from collections import Mapping
+from collections.abc import Mapping
 from .runtime import Undefined
 from ._compat import text_type, string_types, integer_types
 import decimal

--- a/st3/mdpopups/pygments/util.py
+++ b/st3/mdpopups/pygments/util.py
@@ -24,7 +24,7 @@ doctype_lookup_re = re.compile(r'''(?smx)
      )
      [^>]*>
 ''')
-tag_re = re.compile(r'<(.+?)(\s.*?)?>.*?</.+?>(?uism)')
+tag_re = re.compile(r'(?uism)<(.+?)(\s.*?)?>.*?</.+?>')
 xml_decl_re = re.compile(r'\s*<\?xml[^>]*\?>', re.I)
 
 

--- a/st3/mdpopups/st_colormod.py
+++ b/st3/mdpopups/st_colormod.py
@@ -33,8 +33,7 @@ TOKENS = {
 
 RE_ADJUSTERS = {
     "alpha": re.compile(
-        r"""
-        (?xi)
+        r"""(?xi)
         \s+a(?:lpha)?\(\s*
         (?:(\+\s+|\-\s+)?({strict_percent}|{strict_float})|(\*)?\s*({strict_percent}|{strict_float}))
         \s*\)


### PR DESCRIPTION
The latest ST 4201, which replaces py38 with py313, has been released as a private beta in the discord. See [discord.com/channels/280102180189634562/650695903446827011/1432613579223339059](https://discord.com/channels/280102180189634562/650695903446827011/1432613579223339059)

## Issues

There are probably more but these are what I encountered.

- Global regex modifiers must be at the beginning.
- Some abstract classes were moved from `collections` to `collections.abc`. (`collections.abc` works in py33 too)
- `html.parser.HTMLParser().unescape` no longer exists in py313.